### PR TITLE
- Renamed API to create QR scanner plugin and other related issue

### DIFF
--- a/ImageSaverPlugin/src/commonMain/kotlin/com/kashif/imagesaverplugin/ImageSaverPlugin.kt
+++ b/ImageSaverPlugin/src/commonMain/kotlin/com/kashif/imagesaverplugin/ImageSaverPlugin.kt
@@ -72,7 +72,7 @@ abstract class ImageSaverPlugin(
  * @return An instance of [ImageSaverPlugin].
  */
 @Composable
-fun createImageSaverPlugin(
+fun rememberImageSaverPlugin(
     config: ImageSaverConfig,
     context: PlatformContext = LocalPlatformContext.current
 ): ImageSaverPlugin {
@@ -82,7 +82,7 @@ fun createImageSaverPlugin(
 }
 
 /**
- * Platform-specific implementation of the [createImageSaverPlugin] factory function.
+ * Platform-specific implementation of the [rememberImageSaverPlugin] factory function.
  */
 
 expect fun createPlatformImageSaverPlugin(

--- a/README.MD
+++ b/README.MD
@@ -122,7 +122,7 @@ val cameraController = remember { mutableStateOf<CameraController?>(null) }
 After this if needed, create plugins
 
 ```Kotlin
-val imageSaverPlugin = createImageSaverPlugin(
+val imageSaverPlugin = rememberImageSaverPlugin(
     config = ImageSaverConfig(
         isAutoSave = false, // Set to true to enable automatic saving  
         prefix = "MyApp", // Prefix for image names when auto-saving  
@@ -130,10 +130,10 @@ val imageSaverPlugin = createImageSaverPlugin(
         customFolderName = "CustomFolder" // Custom folder name within the directory, only works on android for now  
     )
 )
-val qrScannerPlugin = createQRScannerPlugin(coroutineScope = coroutineScope)
+val qrScannerPlugin = rememberQRScannerPlugin(coroutineScope = coroutineScope)
 
 LaunchedEffect(Unit) {
-    qrScannerPlugin.getQrCodeFlow(500)
+    qrScannerPlugin.getQrCodeFlow().distinctUntilChanged()
         .collectLatest { qrCode ->
             println("QR Code Detected flow: $qrCode")
             snackbarHostState.showSnackbar("QR Code Detected flow: $qrCode")

--- a/Sample/src/commonMain/kotlin/org/company/app/App.kt
+++ b/Sample/src/commonMain/kotlin/org/company/app/App.kt
@@ -24,13 +24,11 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,12 +45,12 @@ import com.kashif.cameraK.result.ImageCaptureResult
 import com.kashif.cameraK.ui.CameraPreview
 import com.kashif.imageSaverPlugin.ImageSaverConfig
 import com.kashif.imageSaverPlugin.ImageSaverPlugin
-import com.kashif.imageSaverPlugin.createImageSaverPlugin
-import com.kashif.qrscannerplugin.createQRScannerPlugin
+import com.kashif.imageSaverPlugin.rememberImageSaverPlugin
+import com.kashif.qrscannerplugin.rememberQRScannerPlugin
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.company.app.theme.AppTheme
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -86,10 +84,10 @@ fun App() = AppTheme {
                 permissions.hasStoragePermission()
             )
         }
-        val qrScannerPlugin = createQRScannerPlugin(coroutineScope = coroutineScope)
+        val qrScannerPlugin = rememberQRScannerPlugin(coroutineScope = coroutineScope)
 
         LaunchedEffect(Unit) {
-            qrScannerPlugin.getQrCodeFlow(500)
+            qrScannerPlugin.getQrCodeFlow().distinctUntilChanged()
                 .collectLatest { qrCode ->
                     println("QR Code Detected flow: $qrCode")
                     snackbarHostState.showSnackbar("QR Code Detected flow: $qrCode")
@@ -98,7 +96,7 @@ fun App() = AppTheme {
         }
 
         val cameraController = remember { mutableStateOf<CameraController?>(null) }
-        val imageSaverPlugin = createImageSaverPlugin(
+        val imageSaverPlugin = rememberImageSaverPlugin(
             config = ImageSaverConfig(
                 isAutoSave = false, // Set to true to enable automatic saving
                 prefix = "MyApp", // Prefix for image names when auto-saving

--- a/qrScannerPlugin/src/commonMain/kotlin/com/kashif/qrscannerplugin/QRScannerPlugin.kt
+++ b/qrScannerPlugin/src/commonMain/kotlin/com/kashif/qrscannerplugin/QRScannerPlugin.kt
@@ -1,21 +1,19 @@
 package com.kashif.qrscannerplugin
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import com.kashif.cameraK.controller.CameraController
-import com.kashif.cameraK.plugins.CameraPlugin
-import kotlinx.atomicfu.AtomicBoolean
-import kotlinx.atomicfu.atomic
-
 /**
  * A plugin for scanning QR codes using the camera.
  *
  * @property onQrScanner A callback function that is invoked when a QR code is scanned.
  */
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.asSharedFlow
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import com.kashif.cameraK.controller.CameraController
+import com.kashif.cameraK.plugins.CameraPlugin
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 
 class QRScannerPlugin(
@@ -73,7 +71,7 @@ class QRScannerPlugin(
      *
      * @return SharedFlow<String>
      */
-    fun getQrCodeFlow(debounce: Long) = qrCodeFlow.asSharedFlow().debounce(debounce)
+    fun getQrCodeFlow() = qrCodeFlow.asSharedFlow()
 }
 
 /**
@@ -94,8 +92,8 @@ expect fun startScanning(
  * @return A remembered instance of QRScannerPlugin.
  */
 @Composable
-fun createQRScannerPlugin(
-    coroutineScope: CoroutineScope
+fun rememberQRScannerPlugin(
+    coroutineScope: CoroutineScope = rememberCoroutineScope()
 ): QRScannerPlugin {
     return remember {
         QRScannerPlugin(coroutineScope)


### PR DESCRIPTION
This pull request includes several changes aimed at improving the composability and efficiency of the `ImageSaverPlugin` and `QRScannerPlugin` modules. The most important changes involve renaming factory functions to use the `remember` pattern, updating the corresponding documentation, and removing unnecessary imports. 

### Improvements to composability:

* [`ImageSaverPlugin/src/commonMain/kotlin/com/kashif/imagesaverplugin/ImageSaverPlugin.kt`](diffhunk://#diff-32a09ebdb51d23e24344d9fa4d9e66e242e12a316c0ea830bc0d359f36c1d5b4L75-R75): Renamed the `createImageSaverPlugin` function to `rememberImageSaverPlugin` and updated the corresponding documentation. [[1]](diffhunk://#diff-32a09ebdb51d23e24344d9fa4d9e66e242e12a316c0ea830bc0d359f36c1d5b4L75-R75) [[2]](diffhunk://#diff-32a09ebdb51d23e24344d9fa4d9e66e242e12a316c0ea830bc0d359f36c1d5b4L85-R85)

* [`qrScannerPlugin/src/commonMain/kotlin/com/kashif/qrscannerplugin/QRScannerPlugin.kt`](diffhunk://#diff-1954090c47e60915d778c410a6da1b22ed798b6742d17540e9074d14aff6efdeL97-R96): Renamed the `createQRScannerPlugin` function to `rememberQRScannerPlugin` and updated the corresponding documentation.

### Documentation updates:

* [`README.MD`](diffhunk://#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaL125-R136): Updated the usage examples to reflect the new `rememberImageSaverPlugin` and `rememberQRScannerPlugin` function names.

### Code cleanup:

* [`Sample/src/commonMain/kotlin/org/company/app/App.kt`](diffhunk://#diff-9e1e24cc3363b071359c3713759f6f75d71bf76dd45bbcd1dba772c54b0c2f42L27-L33): Removed unused imports and updated the plugin instantiation to use the new `remember` functions. [[1]](diffhunk://#diff-9e1e24cc3363b071359c3713759f6f75d71bf76dd45bbcd1dba772c54b0c2f42L27-L33) [[2]](diffhunk://#diff-9e1e24cc3363b071359c3713759f6f75d71bf76dd45bbcd1dba772c54b0c2f42L50-R53) [[3]](diffhunk://#diff-9e1e24cc3363b071359c3713759f6f75d71bf76dd45bbcd1dba772c54b0c2f42L89-R90) [[4]](diffhunk://#diff-9e1e24cc3363b071359c3713759f6f75d71bf76dd45bbcd1dba772c54b0c2f42L101-R99)

* [`qrScannerPlugin/src/commonMain/kotlin/com/kashif/qrscannerplugin/QRScannerPlugin.kt`](diffhunk://#diff-1954090c47e60915d778c410a6da1b22ed798b6742d17540e9074d14aff6efdeL76-R74): Removed the `debounce` parameter from the `getQrCodeFlow` function to simplify the flow management.- Renamed API to create image saver plugin
- removed debounce from qr flow to be more customizable