### PR TITLE
- added github action for lib distribution

### DIFF
--- a/.github/workflows/UploadLibToCentral.yml
+++ b/.github/workflows/UploadLibToCentral.yml
@@ -1,0 +1,30 @@
+name: Upload Library to Maven Central
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    size: large
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Publish to Maven Central
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./gradlew publish --no-configuration-cache


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the process of uploading the library to Maven Central. The most important changes include setting up the workflow, configuring the build environment, and defining the steps for building and publishing the library.

New GitHub Actions workflow:

* [`.github/workflows/UploadLibToCentral.yml`](diffhunk://#diff-c6a7bde02bc7e04b7a7291143cf869aa4b4d5949795df3d7b88dc4c4bd12079fR1-R30): Added a new workflow named "Upload Library to Maven Central" that triggers on `workflow_dispatch`, sets up the build environment using JDK 11, and defines steps for checking out the code, building with Gradle, and publishing to Maven Central.