### PR TITLE
Implement user quality prioritization settings for image capture

### DIFF
--- a/Sample/src/commonMain/kotlin/org/company/app/App.kt
+++ b/Sample/src/commonMain/kotlin/org/company/app/App.kt
@@ -57,6 +57,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.permissions.Permissions
 import com.kashif.cameraK.permissions.providePermissions
@@ -157,6 +158,7 @@ private fun CameraContent(
                 setImageFormat(ImageFormat.JPEG)
                 setDirectory(Directory.PICTURES)
                 setTorchMode(TorchMode.OFF)
+                setQualityPrioritization(QualityPrioritization.QUALITY)
                 addPlugin(imageSaverPlugin)
             },
             onCameraControllerReady = {

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.android.kt
@@ -7,6 +7,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.plugins.CameraPlugin
 import com.kashif.cameraK.utils.InvalidConfigurationException
@@ -28,6 +29,7 @@ class AndroidCameraControllerBuilder(
     private var imageFormat: ImageFormat? = null
     private var directory: Directory? = null
     private var torchMode: TorchMode = TorchMode.AUTO
+    private var qualityPriority: QualityPrioritization = QualityPrioritization.NONE
     private val plugins = mutableListOf<CameraPlugin>()
 
     override fun setFlashMode(flashMode: FlashMode): CameraControllerBuilder {
@@ -43,6 +45,11 @@ class AndroidCameraControllerBuilder(
 
     override fun setTorchMode(torchMode: TorchMode): CameraControllerBuilder {
         this.torchMode = torchMode
+        return this
+    }
+
+    override fun setQualityPrioritization(prioritization: QualityPrioritization): CameraControllerBuilder {
+        this.qualityPriority = prioritization
         return this
     }
 
@@ -78,7 +85,8 @@ class AndroidCameraControllerBuilder(
             imageFormat = format,
             directory = dir,
             plugins = plugins,
-            torchMode = torchMode
+            torchMode = torchMode,
+            qualityPriority = qualityPriority
         )
         plugins.forEach {
             it.initialize(cameraController)

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.apple.kt
@@ -16,6 +16,7 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
     private var cameraLens: CameraLens = CameraLens.BACK
     private var imageFormat: ImageFormat? = null
     private var directory: Directory? = null
+    private var qualityPriority: QualityPrioritization = QualityPrioritization.NONE
     private val plugins = mutableListOf<CameraPlugin>()
 
     override fun setFlashMode(flashMode: FlashMode): CameraControllerBuilder {
@@ -37,6 +38,11 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
 
     override fun setTorchMode(torchMode: TorchMode): CameraControllerBuilder {
         this.torchMode = torchMode
+        return this
+    }
+
+    override fun setQualityPrioritization(prioritization: QualityPrioritization): CameraControllerBuilder {
+        this.qualityPriority = prioritization
         return this
     }
 
@@ -62,7 +68,8 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
             cameraLens = cameraLens,
             imageFormat = format,
             directory = dir,
-            plugins = plugins
+            plugins = plugins,
+            qualityPriority = qualityPriority
         )
 
         return cameraController

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/Controller.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/Controller.apple.kt
@@ -5,6 +5,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.plugins.CameraPlugin
 import com.kashif.cameraK.result.ImageCaptureResult
@@ -47,11 +48,12 @@ actual class CameraController(
     internal var torchMode: TorchMode,
     internal var cameraLens: CameraLens,
     internal var imageFormat: ImageFormat,
+    internal var qualityPriority: QualityPrioritization,
     internal var directory: Directory,
     internal var plugins: MutableList<CameraPlugin>
 ) : UIViewController(null, null) {
     private var isCapturing = atomic(false)
-    private val customCameraController = CustomCameraController()
+    private val customCameraController = CustomCameraController(qualityPriority)
     private var imageCaptureListeners = mutableListOf<(ByteArray) -> Unit>()
     private var metadataOutput = AVCaptureMetadataOutput()
     private var metadataObjectsDelegate: AVCaptureMetadataOutputObjectsDelegateProtocol? = null

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCamera.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCamera.kt
@@ -1,5 +1,6 @@
 package com.kashif.cameraK.controller
 
+import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.utils.MemoryManager
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.AVFoundation.*
@@ -14,7 +15,7 @@ import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_global_queue
 
-class CustomCameraController : NSObject(), AVCapturePhotoCaptureDelegateProtocol {
+class CustomCameraController(val qualityPriority: QualityPrioritization) : NSObject(), AVCapturePhotoCaptureDelegateProtocol {
     var captureSession: AVCaptureSession? = null
     private var backCamera: AVCaptureDevice? = null
     private var frontCamera: AVCaptureDevice? = null
@@ -61,6 +62,26 @@ class CustomCameraController : NSObject(), AVCapturePhotoCaptureDelegateProtocol
     private fun setupPhotoOutput() {
         photoOutput = AVCapturePhotoOutput()
         photoOutput?.setHighResolutionCaptureEnabled(false)
+
+        when (qualityPriority) {
+            QualityPrioritization.QUALITY -> {
+                photoOutput?.setHighResolutionCaptureEnabled(true)
+                photoOutput?.setMaxPhotoQualityPrioritization(
+                    AVCapturePhotoQualityPrioritizationQuality
+                )
+            }
+
+            QualityPrioritization.BALANCED -> photoOutput?.setMaxPhotoQualityPrioritization(
+                AVCapturePhotoQualityPrioritizationBalanced
+            )
+
+            QualityPrioritization.SPEED -> photoOutput?.setMaxPhotoQualityPrioritization(
+                AVCapturePhotoQualityPrioritizationSpeed
+            )
+
+            QualityPrioritization.NONE -> null
+        }
+
         photoOutput?.setPreparedPhotoSettingsArray(emptyList<String>(), completionHandler = { settings, error ->
             if (error != null) {
                 onError?.invoke(CameraException.ConfigurationError(error.localizedDescription))
@@ -232,6 +253,22 @@ class CustomCameraController : NSObject(), AVCapturePhotoCaptureDelegateProtocol
 
         settings.setHighResolutionPhotoEnabled(false)
 
+        when (qualityPriority) {
+            QualityPrioritization.QUALITY -> {
+                settings.setHighResolutionPhotoEnabled(true)
+                settings.photoQualityPrioritization = AVCapturePhotoQualityPrioritizationQuality
+            }
+
+            QualityPrioritization.BALANCED -> {
+                settings.photoQualityPrioritization = AVCapturePhotoQualityPrioritizationBalanced
+            }
+
+            QualityPrioritization.SPEED -> {
+                settings.photoQualityPrioritization = AVCapturePhotoQualityPrioritizationSpeed
+            }
+
+            QualityPrioritization.NONE -> null
+        }
 
         settings.flashMode = this.flashMode
 

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.kt
@@ -5,6 +5,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.plugins.CameraPlugin
 
@@ -34,4 +35,9 @@ interface CameraControllerBuilder {
      */
     fun build(): CameraController
     fun setTorchMode(torchMode: TorchMode): CameraControllerBuilder
+
+    /**
+     * Sets the quality prioritization for the captured image.
+     */
+    fun setQualityPrioritization(prioritization: QualityPrioritization): CameraControllerBuilder
 }

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/QualityPrioritization.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/QualityPrioritization.kt
@@ -1,0 +1,11 @@
+package com.kashif.cameraK.enums
+
+/**
+ * Enum class representing the quality prioritization options for image capture.
+ */
+enum class QualityPrioritization {
+    QUALITY,
+    SPEED,
+    BALANCED,
+    NONE
+}

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/DesktopCameraControllerBuilder.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/DesktopCameraControllerBuilder.kt
@@ -5,6 +5,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.plugins.CameraPlugin
 import com.kashif.cameraK.utils.InvalidConfigurationException
@@ -22,6 +23,7 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
     private var cameraLens: CameraLens = CameraLens.BACK
     private var imageFormat: ImageFormat? = null
     private var directory: Directory? = null
+    private var qualityPriority: QualityPrioritization = QualityPrioritization.NONE
     private val plugins = mutableListOf<CameraPlugin>()
 
     fun setGrabber(grabber: FrameGrabber): CameraControllerBuilder {
@@ -51,6 +53,11 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
 
     override fun setTorchMode(torchMode: TorchMode): CameraControllerBuilder {
         this.torchMode = torchMode
+        return this
+    }
+
+    override fun setQualityPrioritization(prioritization: QualityPrioritization): CameraControllerBuilder {
+        this.qualityPriority = prioritization
         return this
     }
 


### PR DESCRIPTION
-   Added `QualityPrioritization` enum to represent prioritization options.
-   Added `setQualityPrioritization` function to `CameraControllerBuilder` across platforms.
-   Added modifications for Android and iOS.
-   Updated the sample application to set the quality priority.

⚠️ Missing desktop implementation

note: @Kashif-E I hope you can review this PR and give me feedback about it. I stumble upon this problem on my own app so I made this addition to your code. Thanks in advance.