### PR TITLE
Add setNeedsUpdateProperties() to CameraController

### DIFF
--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -119,6 +119,10 @@ actual class CameraController(
         customCameraController.safeAddOutput(output)
     }
 
+    override fun setNeedsUpdateProperties(context: UIFocusUpdateContext?) {
+        super.setNeedsUpdateProperties(context)
+    }
+
     internal fun currentVideoOrientation(): AVCaptureVideoOrientation {
         val orientation = UIDevice.currentDevice.orientation
         return when (orientation) {


### PR DESCRIPTION
Overrides function to fix iOS build in Xcode

# Summary

Added override to prevent Xcode build Error.

## Changes

- Added `setNeedsUpdateProperties` override to CameraController

## Checklist

- [x] I tested these changes locally
- [ ] I updated or added relevant tests
- [ ] I updated documentation when needed
- [ ] I verified there are no breaking changes (or documented them)

## Screenshots (if applicable)


## Related Issues

[Related issue](https://github.com/Kashif-E/CameraK/issues/97)