### PR TITLE
Fix unbuildable desktop sample due to missing kflite

### DIFF
--- a/Sample/build.gradle.kts
+++ b/Sample/build.gradle.kts
@@ -28,8 +28,12 @@ kotlin {
         }
     }
 
+    applyDefaultHierarchyTemplate()
+
     sourceSets {
         val desktopMain by getting
+
+        val mobileMain by creating
 
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -45,8 +49,26 @@ kotlin {
             implementation(projects.ocrPlugin)
             implementation(projects.videoRecorderPlugin)
             implementation(libs.lucide.icons.cmp)
+        }
+
+        mobileMain.dependsOn(commonMain.get())
+
+        mobileMain.dependencies {
             implementation(libs.kflite)
         }
+
+        androidMain {
+            dependsOn(mobileMain)
+            dependencies {
+                implementation(compose.uiTooling)
+                implementation(libs.androidx.activityCompose)
+            }
+        }
+
+        iosMain {
+            dependsOn(mobileMain)
+        }
+
 
         commonTest.dependencies {
             implementation(kotlin("test"))
@@ -71,7 +93,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 24
         targetSdk = 34
 
         applicationId = "org.company.app.androidApp"

--- a/Sample/src/commonMain/kotlin/org/company/app/App.kt
+++ b/Sample/src/commonMain/kotlin/org/company/app/App.kt
@@ -55,10 +55,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.decodeToImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -100,7 +100,6 @@ import com.kashif.cameraK.result.ImageCaptureResult
 import com.kashif.cameraK.state.CameraConfiguration
 import com.kashif.cameraK.state.CameraKEvent
 import com.kashif.cameraK.state.CameraKState
-import com.kashif.cameraK.state.CameraKStateHolder
 import com.kashif.cameraK.video.VideoConfiguration
 import com.kashif.cameraK.video.VideoQuality
 import com.kashif.imagesaverplugin.ImageSaverConfig
@@ -421,8 +420,12 @@ private fun CameraScreen(
         zoomLevel = cameraController.getZoom()
     }
 
-    LaunchedEffect(latestFrame) {
-        latestFrame?.runTFliteModel()
+    val runTFliteModel = remember { getTFliteRunner() }
+
+    if(runTFliteModel != null) {
+        LaunchedEffect(latestFrame) {
+            latestFrame?.runTFliteModel(scope)
+        }
     }
 
     Box(

--- a/Sample/src/commonMain/kotlin/org/company/app/Util.kt
+++ b/Sample/src/commonMain/kotlin/org/company/app/Util.kt
@@ -1,13 +1,6 @@
 package org.company.app
 
-import org.kmp.playground.kflite.DelegateType
-import org.kmp.playground.kflite.InterpreterOptions
-import org.kmp.playground.kflite.Kflite
-import org.kmp.playground.kflite.bytesToScaledByteBuffer
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
-import cameracompose.sample.generated.resources.Res
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Multiplatform-safe alternative to `String.format` for simple numeric formatting.
@@ -99,57 +92,4 @@ private fun Double.pow(n: Int): Double {
 }
 
 
-private const val FLOAT_TYPE_SIZE = 3
-private const val PIXEL_SIZE = 1
-@Composable
-fun ByteArray.runTFliteModel() {
-    val scope = rememberCoroutineScope()
-    scope.launch {
-        Kflite.init(
-            model = Res.readBytes("files/efficientdet-lite2.tflite"),
-            options = InterpreterOptions(
-                numThreads = 4,
-                delegateType = DelegateType.NNAPI_COREML,
-                allowFp16PrecisionForFp32 = true
-            )
-        )
-
-        println("TensorInputCount: ${Kflite.getInputTensorCount()}")
-        println("TensorOutputCount: ${Kflite.getOutputTensorCount()}")
-
-        // Prepare input data: Example model takes 4D array as an input
-        val inputImageWidth = Kflite.getInputTensor(0).shape[1]
-        val inputImageHeight = Kflite.getInputTensor(0).shape[2]
-        val modelInputSize =
-            FLOAT_TYPE_SIZE * inputImageWidth * inputImageHeight * PIXEL_SIZE
-
-        // Prepare output data: Example model has 3D array as an output
-        val firstOutputShape = Kflite.getOutputTensor(0).shape[0]
-        val secondOutputShape = Kflite.getOutputTensor(0).shape[1]
-        val thirdOutputShape = Kflite.getOutputTensor(0).shape[2]
-
-        println("firstOutputTensor: ${firstOutputShape}, secondOutputTensorShape: $secondOutputShape, ThirdOutputTensorShape: $thirdOutputShape")
-
-        val modelOutputSize = Array(firstOutputShape) {
-            Array(secondOutputShape) {
-                FloatArray(thirdOutputShape)
-            }
-        }
-
-        // Run model
-        Kflite.run(
-            listOf(
-                this@runTFliteModel.bytesToScaledByteBuffer(
-                    inputWidth = inputImageWidth,
-                    inputHeight = inputImageHeight,
-                    inputAllocateSize = modelInputSize
-                )
-            ),
-            mapOf(Pair(0, modelOutputSize))
-        )
-        println("Output of first detection: ${modelOutputSize[0][0].joinToString()}")
-
-        // Close model after use
-        Kflite.close()
-    }
-}
+expect fun getTFliteRunner(): (ByteArray.(CoroutineScope) -> Unit)?

--- a/Sample/src/desktopMain/kotlin/org/company/app/Util.desktop.kt
+++ b/Sample/src/desktopMain/kotlin/org/company/app/Util.desktop.kt
@@ -1,0 +1,5 @@
+package org.company.app
+
+import kotlinx.coroutines.CoroutineScope
+
+actual fun getTFliteRunner(): (ByteArray.(CoroutineScope) -> Unit)? = null

--- a/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
+++ b/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
@@ -1,0 +1,65 @@
+package org.company.app
+
+import cameracompose.sample.generated.resources.Res
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.kmp.playground.kflite.DelegateType
+import org.kmp.playground.kflite.InterpreterOptions
+import org.kmp.playground.kflite.Kflite
+import org.kmp.playground.kflite.bytesToScaledByteBuffer
+
+const val FLOAT_TYPE_SIZE = 3
+const val PIXEL_SIZE = 1
+
+actual fun getTFliteRunner(): (ByteArray.(CoroutineScope) -> Unit)? = ByteArray::runTFliteModel
+
+fun ByteArray.runTFliteModel(scope: CoroutineScope) {
+    scope.launch {
+        Kflite.init(
+            model = Res.readBytes("files/efficientdet-lite2.tflite"),
+            options = InterpreterOptions(
+                numThreads = 4,
+                delegateType = DelegateType.NNAPI_COREML,
+                allowFp16PrecisionForFp32 = true
+            )
+        )
+
+        println("TensorInputCount: ${Kflite.getInputTensorCount()}")
+        println("TensorOutputCount: ${Kflite.getOutputTensorCount()}")
+
+        // Prepare input data: Example model takes 4D array as an input
+        val inputImageWidth = Kflite.getInputTensor(0).shape[1]
+        val inputImageHeight = Kflite.getInputTensor(0).shape[2]
+        val modelInputSize =
+            FLOAT_TYPE_SIZE * inputImageWidth * inputImageHeight * PIXEL_SIZE
+
+        // Prepare output data: Example model has 3D array as an output
+        val firstOutputShape = Kflite.getOutputTensor(0).shape[0]
+        val secondOutputShape = Kflite.getOutputTensor(0).shape[1]
+        val thirdOutputShape = Kflite.getOutputTensor(0).shape[2]
+
+        println("firstOutputTensor: ${firstOutputShape}, secondOutputTensorShape: $secondOutputShape, ThirdOutputTensorShape: $thirdOutputShape")
+
+        val modelOutputSize = Array(firstOutputShape) {
+            Array(secondOutputShape) {
+                FloatArray(thirdOutputShape)
+            }
+        }
+
+        // Run model
+        Kflite.run(
+            listOf(
+                this@runTFliteModel.bytesToScaledByteBuffer(
+                    inputWidth = inputImageWidth,
+                    inputHeight = inputImageHeight,
+                    inputAllocateSize = modelInputSize
+                )
+            ),
+            mapOf(Pair(0, modelOutputSize))
+        )
+        println("Output of first detection: ${modelOutputSize[0][0].joinToString()}")
+
+        // Close model after use
+        Kflite.close()
+    }
+}


### PR DESCRIPTION
# Summary
I've fixed unbuildable sample by moving kflite dependencies to their own target

## Changes

- Created new sourceset mobileMain, which targets iOS and Android
- Moved relevant ktflite functions to mobileMain

## Checklist

- [x] I tested these changes locally
- [ ] I updated or added relevant tests
- [ ] I updated documentation when needed
- [x] I verified there are no breaking changes (or documented them)

## Screenshots (if applicable)

N/A

## Related Issues

#122, ShadAdman/kflite#12