### PR TITLE
Add CI build check (all targets)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Compile all targets
+        run: >
+          ./gradlew --no-daemon
+          compileDebugKotlinAndroid
+          compileReleaseKotlinAndroid
+          compileKotlinDesktop
+          compileKotlinIosX64
+          compileKotlinIosArm64
+          compileKotlinIosSimulatorArm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest
@@ -16,6 +19,13 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
+
+      - name: Cache Kotlin/Native (~/.konan)
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: konan-${{ runner.os }}-
 
       - uses: gradle/actions/setup-gradle@v4
 


### PR DESCRIPTION
Adds a `Build` workflow that compiles every target on each PR and on pushes to `main`:

- Android (debug + release), Desktop (JVM), iOS (x64 / arm64 / simulator-arm64)
- Runs on `macos-latest` with JDK 17

Intended to back a branch-protection rule: require this check + conversation resolution before merging.