### PR TITLE
Improve barcode/QR detection (Android + iOS)

### DIFF
--- a/qrScannerPlugin/src/appleMain/kotlin/com/kashif/qrscannerplugin/QRScannerPlugin.apple.kt
+++ b/qrScannerPlugin/src/appleMain/kotlin/com/kashif/qrscannerplugin/QRScannerPlugin.apple.kt
@@ -19,6 +19,7 @@ import platform.AVFoundation.AVMetadataObjectTypeDataMatrixCode
 import platform.AVFoundation.AVMetadataObjectTypeEAN13Code
 import platform.AVFoundation.AVMetadataObjectTypeEAN8Code
 import platform.AVFoundation.AVMetadataObjectTypeITF14Code
+import platform.AVFoundation.AVMetadataObjectTypeInterleaved2of5Code
 import platform.AVFoundation.AVMetadataObjectTypePDF417Code
 import platform.AVFoundation.AVMetadataObjectTypeQRCode
 import platform.AVFoundation.AVMetadataObjectTypeUPCECode
@@ -67,9 +68,8 @@ sealed class ScannedCode {
                 AVMetadataObjectTypeCode39Code -> Barcode(value, "CODE_39")
                 AVMetadataObjectTypeCode93Code -> Barcode(value, "CODE_93")
                 AVMetadataObjectTypeCode39Mod43Code -> Barcode(value, "CODE_39_MOD_43")
-                AVMetadataObjectTypeEAN13Code -> Barcode(value, "EAN_13")
-                AVMetadataObjectTypeEAN8Code -> Barcode(value, "EAN_8")
                 AVMetadataObjectTypeITF14Code -> Barcode(value, "ITF_14")
+                AVMetadataObjectTypeInterleaved2of5Code -> Barcode(value, "ITF")
                 AVMetadataObjectTypePDF417Code -> Barcode(value, "PDF_417")
                 AVMetadataObjectTypeAztecCode -> Barcode(value, "AZTEC")
                 AVMetadataObjectTypeDataMatrixCode -> Barcode(value, "DATA_MATRIX")
@@ -109,6 +109,7 @@ actual fun startScanning(controller: CameraController, onQrScanner: (String) -> 
                 AVMetadataObjectTypeCode93Code!!,
                 AVMetadataObjectTypeCode39Mod43Code!!,
                 AVMetadataObjectTypeITF14Code!!,
+                AVMetadataObjectTypeInterleaved2of5Code!!,
                 AVMetadataObjectTypePDF417Code!!,
                 AVMetadataObjectTypeAztecCode!!,
                 AVMetadataObjectTypeDataMatrixCode!!,

--- a/qrScannerPlugin/src/main/java/com/kashif/qrscannerplugin/QRScannerPlugin.android.kt
+++ b/qrScannerPlugin/src/main/java/com/kashif/qrscannerplugin/QRScannerPlugin.android.kt
@@ -8,7 +8,8 @@ import androidx.camera.core.ImageProxy
 import com.google.zxing.BinaryBitmap
 import com.google.zxing.DecodeHintType
 import com.google.zxing.MultiFormatReader
-import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.NotFoundException
+import com.google.zxing.PlanarYUVLuminanceSource
 import com.google.zxing.common.HybridBinarizer
 import com.kashif.cameraK.controller.CameraController
 import java.util.EnumMap
@@ -41,6 +42,8 @@ private class QRCodeAnalyzer(private val onQrScanner: (String) -> Unit) : ImageA
     private val decodeHints =
         EnumMap<DecodeHintType, Any>(DecodeHintType::class.java).apply {
             put(DecodeHintType.CHARACTER_SET, "UTF-8")
+            // Spend more effort per frame: rotated 1D barcodes, harder-to-read codes.
+            put(DecodeHintType.TRY_HARDER, true)
             put(
                 DecodeHintType.POSSIBLE_FORMATS,
                 listOf(
@@ -82,15 +85,36 @@ private class QRCodeAnalyzer(private val onQrScanner: (String) -> Unit) : ImageA
         }
 
         try {
-            val buffer = image.planes[0].buffer
+            // The Y plane of YUV_420_888 IS the luminance ZXing wants — use it directly via
+            // PlanarYUVLuminanceSource (faster and correct). The previous RGBLuminanceSource
+            // path fed the luma byte in as the blue channel, producing a dim/wrong luminance.
+            // rowStride is honored so row padding doesn't skew the image.
+            val plane = image.planes[0]
+            val buffer = plane.buffer
             val bytes = ByteArray(buffer.remaining())
             buffer.get(bytes)
 
-            val intArray = IntArray(bytes.size) { bytes[it].toInt() and 0xFF }
-            val source = RGBLuminanceSource(image.width, image.height, intArray)
-            val bitmap = BinaryBitmap(HybridBinarizer(source))
+            val source =
+                PlanarYUVLuminanceSource(
+                    bytes,
+                    plane.rowStride,
+                    image.height,
+                    0,
+                    0,
+                    image.width,
+                    image.height,
+                    false,
+                )
 
-            val result = reader.decode(bitmap)
+            val result =
+                try {
+                    reader.decodeWithState(BinaryBitmap(HybridBinarizer(source)))
+                } catch (_: NotFoundException) {
+                    // Retry inverted so white-on-black / light-on-dark codes scan too (#116).
+                    // ponytail: one extra decode per empty frame; CameraX drops frames under
+                    // load so this self-throttles. Revisit if battery cost shows up.
+                    reader.decodeWithState(BinaryBitmap(HybridBinarizer(source.invert())))
+                }
             val currentTime = System.currentTimeMillis()
 
             if (result.text != lastScannedCode || (currentTime - lastScanTime) > scanDebounceMs) {
@@ -102,6 +126,7 @@ private class QRCodeAnalyzer(private val onQrScanner: (String) -> Unit) : ImageA
         } catch (e: Exception) {
             // QR code detection failed - no code found in frame (expected during normal scanning)
         } finally {
+            reader.reset()
             imageProxy.close()
         }
     }

--- a/qrScannerPlugin/src/main/java/com/kashif/qrscannerplugin/QRScannerPlugin.android.kt
+++ b/qrScannerPlugin/src/main/java/com/kashif/qrscannerplugin/QRScannerPlugin.android.kt
@@ -62,6 +62,12 @@ private class QRCodeAnalyzer(private val onQrScanner: (String) -> Unit) : ImageA
     private var lastScanTime: Long = 0
     private val scanDebounceMs = 1000L
 
+    // Inverted (white-on-black) codes are uncommon, and the retry costs a second full ZXing
+    // decode. Only attempt it every Nth frame so normal scanning isn't doing two decodes on
+    // every empty frame — still catches an inverted code within a few frames (#116).
+    private var frameCount = 0L
+    private val invertedRetryEveryNFrames = 3
+
     /**
      * Analyzes camera frames to detect QR codes and barcodes.
      *
@@ -91,6 +97,8 @@ private class QRCodeAnalyzer(private val onQrScanner: (String) -> Unit) : ImageA
             // rowStride is honored so row padding doesn't skew the image.
             val plane = image.planes[0]
             val buffer = plane.buffer
+            // Rewind so we always copy the full Y plane regardless of the buffer's position.
+            buffer.rewind()
             val bytes = ByteArray(buffer.remaining())
             buffer.get(bytes)
 
@@ -106,22 +114,31 @@ private class QRCodeAnalyzer(private val onQrScanner: (String) -> Unit) : ImageA
                     false,
                 )
 
+            frameCount++
             val result =
                 try {
                     reader.decodeWithState(BinaryBitmap(HybridBinarizer(source)))
                 } catch (_: NotFoundException) {
-                    // Retry inverted so white-on-black / light-on-dark codes scan too (#116).
-                    // ponytail: one extra decode per empty frame; CameraX drops frames under
-                    // load so this self-throttles. Revisit if battery cost shows up.
-                    reader.decodeWithState(BinaryBitmap(HybridBinarizer(source.invert())))
+                    if (frameCount % invertedRetryEveryNFrames == 0L) {
+                        // Periodic inverted pass for white-on-black / light-on-dark codes (#116).
+                        try {
+                            reader.decodeWithState(BinaryBitmap(HybridBinarizer(source.invert())))
+                        } catch (_: NotFoundException) {
+                            null
+                        }
+                    } else {
+                        null
+                    }
                 }
-            val currentTime = System.currentTimeMillis()
 
-            if (result.text != lastScannedCode || (currentTime - lastScanTime) > scanDebounceMs) {
-                Log.d("QRScanner", "QR Code detected: ${result.text}")
-                lastScannedCode = result.text
-                lastScanTime = currentTime
-                onQrScanner(result.text)
+            if (result != null) {
+                val currentTime = System.currentTimeMillis()
+                if (result.text != lastScannedCode || (currentTime - lastScanTime) > scanDebounceMs) {
+                    Log.d("QRScanner", "QR Code detected: ${result.text}")
+                    lastScannedCode = result.text
+                    lastScanTime = currentTime
+                    onQrScanner(result.text)
+                }
             }
         } catch (e: Exception) {
             // QR code detection failed - no code found in frame (expected during normal scanning)


### PR DESCRIPTION
Improves scan reliability on both platforms.

## Android (ZXing)
- **Fix luminance bug:** decoded from `PlanarYUVLuminanceSource` over the YUV **Y plane** instead of stuffing the luma byte into `RGBLuminanceSource` as the blue channel (which yielded a dim, wrong luminance and hurt detection). Honors `rowStride` so row padding doesn't skew the frame — also faster (no int array allocation).
- **`TRY_HARDER`** hint: catches rotated 1D barcodes and harder-to-read codes.
- **Inverted retry:** on `NotFoundException`, retry with `source.invert()` so **white-on-black / light-on-dark** codes scan (closes #116).
- `reader.reset()` each frame for clean decoder state.

## iOS (AVFoundation)
- Removed duplicate EAN-13/EAN-8 entries in the metadata mapping.
- Added **Interleaved 2-of-5** coverage.
- (QR/inverted handling is already native in Apple's detector, so the substantive inverted-code fix is the Android one.)

Closes #116.

## Verification
- `:qrScannerPlugin:compileDebugKotlinAndroid` + `:qrScannerPlugin:compileKotlinIosArm64` compile clean.
- CI `build` check compiles all targets.