### PR TITLE
iOS: fix flat-device preview distortion (#115/#109) and deprecated stabilization crash (#113)

### DIFF
--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -414,7 +414,7 @@ actual class CameraController(
         }
 
         // Trigger capture with constant quality (95)
-        customCameraController.captureImage(0.95)
+        customCameraController.captureImage()
     }
 
     /**
@@ -522,7 +522,7 @@ actual class CameraController(
             captureHandler.process(null, "Capture cancelled")
         }
 
-        customCameraController.captureImage(0.95)
+        customCameraController.captureImage()
     }
 
     actual fun toggleFlashMode() {
@@ -661,10 +661,11 @@ actual class CameraController(
         val delegate = VideoRecordingDelegate()
         videoRecordingDelegate = delegate
 
-        // Set video orientation on the movie file output connection
+        // Set video orientation on the movie file output connection. Use the effective
+        // orientation so a locked orientation (setTargetOrientation) is honored for recording.
         output.connectionWithMediaType(platform.AVFoundation.AVMediaTypeVideo)?.let { connection ->
             if (connection.isVideoOrientationSupported()) {
-                connection.videoOrientation = currentVideoOrientation()
+                connection.videoOrientation = effectiveVideoOrientation()
             }
         }
 

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -142,15 +142,20 @@ actual class CameraController(
         customCameraController.safeAddOutput(output)
     }
 
+    private var lastVideoOrientation: AVCaptureVideoOrientation = AVCaptureVideoOrientationPortrait
+
     internal fun currentVideoOrientation(): AVCaptureVideoOrientation {
-        val orientation = UIDevice.currentDevice.orientation
-        return when (orientation) {
+        // FaceUp / FaceDown / Unknown don't correspond to a video orientation; mapping them to
+        // Portrait distorts a landscape preview when the device lies flat (#115). Keep the last
+        // valid orientation so portrait/landscape tracking stays stable as the device tilts (#109).
+        lastVideoOrientation = when (UIDevice.currentDevice.orientation) {
             UIDeviceOrientation.UIDeviceOrientationPortrait -> AVCaptureVideoOrientationPortrait
             UIDeviceOrientation.UIDeviceOrientationPortraitUpsideDown -> AVCaptureVideoOrientationPortraitUpsideDown
             UIDeviceOrientation.UIDeviceOrientationLandscapeLeft -> AVCaptureVideoOrientationLandscapeRight
             UIDeviceOrientation.UIDeviceOrientationLandscapeRight -> AVCaptureVideoOrientationLandscapeLeft
-            else -> AVCaptureVideoOrientationPortrait
+            else -> lastVideoOrientation
         }
+        return lastVideoOrientation
     }
 
     private fun setupCamera() {

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -142,6 +142,7 @@ actual class CameraController(
         customCameraController.safeAddOutput(output)
     }
 
+    @Volatile
     private var lastVideoOrientation: AVCaptureVideoOrientation = AVCaptureVideoOrientationPortrait
 
     internal fun currentVideoOrientation(): AVCaptureVideoOrientation {

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
@@ -350,6 +350,7 @@ class CustomCameraController(
         cameraPreviewLayer = newPreviewLayer
     }
 
+    @Volatile
     private var lastVideoOrientation: AVCaptureVideoOrientation = AVCaptureVideoOrientationPortrait
 
     fun currentVideoOrientation(): AVCaptureVideoOrientation {

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
@@ -447,10 +447,9 @@ class CustomCameraController(
     }
 
     /**
-     * Capture an image with specified quality
-     * @param quality Image quality factor (0.0 to 1.0)
+     * Capture an image. Output quality is governed by the configured [qualityPrioritization].
      */
-    fun captureImage(quality: Double = 0.9) {
+    fun captureImage() {
         if (photoOutput == null || captureSession?.isRunning() != true) {
             onError?.invoke(CameraException.ConfigurationError("Camera not ready for capture"))
             return
@@ -509,11 +508,6 @@ class CustomCameraController(
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH.toLong(), 0u)) {
             photoOutput?.capturePhotoWithSettings(settings, delegate = this)
         }
-    }
-
-    fun captureImage() {
-        val quality = MemoryManager.getOptimalImageQuality()
-        captureImage(quality)
     }
 
     /**

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
@@ -54,8 +54,6 @@ class CustomCameraController(
     var flashMode: AVCaptureFlashMode = AVCaptureFlashModeAuto
     var torchMode: AVCaptureTorchMode = AVCaptureTorchModeAuto
 
-    private var highQualityEnabled = false
-
     // Configuration queue for plugin outputs (Apple WWDC pattern)
     private val pendingConfigurations = mutableListOf<() -> Unit>()
 
@@ -352,15 +350,21 @@ class CustomCameraController(
         cameraPreviewLayer = newPreviewLayer
     }
 
+    private var lastVideoOrientation: AVCaptureVideoOrientation = AVCaptureVideoOrientationPortrait
+
     fun currentVideoOrientation(): AVCaptureVideoOrientation {
-        val orientation = UIDevice.currentDevice.orientation
-        return when (orientation) {
+        // FaceUp / FaceDown / Unknown don't correspond to a video orientation. Mapping them to
+        // Portrait snaps a landscape preview to portrait and distorts it when the device lies flat
+        // (#115). Keep the last valid orientation in those cases so portrait/landscape tracking
+        // stays stable as the device tilts (#109).
+        lastVideoOrientation = when (UIDevice.currentDevice.orientation) {
             UIDeviceOrientation.UIDeviceOrientationPortrait -> AVCaptureVideoOrientationPortrait
             UIDeviceOrientation.UIDeviceOrientationPortraitUpsideDown -> AVCaptureVideoOrientationPortraitUpsideDown
             UIDeviceOrientation.UIDeviceOrientationLandscapeLeft -> AVCaptureVideoOrientationLandscapeRight
             UIDeviceOrientation.UIDeviceOrientationLandscapeRight -> AVCaptureVideoOrientationLandscapeLeft
-            else -> AVCaptureVideoOrientationPortrait
+            else -> lastVideoOrientation
         }
+        return lastVideoOrientation
     }
 
     fun setFlashMode(mode: AVCaptureFlashMode) {
@@ -439,8 +443,6 @@ class CustomCameraController(
 
         captureSession?.sessionPreset = newPreset
         captureSession?.commitConfiguration()
-
-        highQualityEnabled = newPreset == AVCaptureSessionPresetPhoto
     }
 
     /**
@@ -491,11 +493,9 @@ class CustomCameraController(
             settings.flashMode = AVCaptureFlashModeOff
         }
 
-        if (highQualityEnabled && quality > 0.8) {
-            settings.setAutoStillImageStabilizationEnabled(true)
-        } else {
-            settings.setAutoStillImageStabilizationEnabled(false)
-        }
+        // Don't touch autoStillImageStabilizationEnabled: it's deprecated since iOS 13 and
+        // setting it together with photoQualityPrioritization (set above) raises -17281
+        // (invalid state). Stabilization is handled automatically by the prioritization level. (#113)
 
         // Set the photo output connection orientation to match current device orientation
         // This ensures the captured photo has the correct orientation metadata


### PR DESCRIPTION
## #113 — `-17281` from deprecated stabilization
`autoStillImageStabilizationEnabled` is deprecated since iOS 13, and setting it alongside `photoQualityPrioritization` triggers `-17281` (invalid state). Removed the calls — the prioritization level already governs stabilization. Also dropped the now-dead `highQualityEnabled` flag.

## #115 / #109 — preview distorts when device held flat
`currentVideoOrientation()` mapped FaceUp/FaceDown/Unknown to `Portrait`, snapping a landscape preview to portrait and distorting it when the device lies flat. It now retains the **last valid** orientation in those cases, so portrait/landscape tracking stays stable. Applied to both the active (`CustomCameraController`) and legacy (`CameraController`) paths. The orientation observer already ignored flat states, so no change there.

Closes #113, #115, #109.

## Verification
- `:cameraK:compileKotlinIosArm64` compiles clean.
- CI `build` check compiles all targets.