### PR TITLE
Add mirrorFrontCamera option to flip front-camera captures (#112)

### DIFF
--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/builder/AndroidCameraControllerBuilder.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/builder/AndroidCameraControllerBuilder.kt
@@ -33,7 +33,13 @@ class AndroidCameraControllerBuilder(private val context: Context, private val l
     private var returnFilePath: Boolean = false
     private var aspectRatio: AspectRatio = AspectRatio.RATIO_4_3
     private var targetResolution: Pair<Int, Int>? = null
+    private var mirrorFrontCamera: Boolean = false
     private val plugins = mutableListOf<CameraPlugin>()
+
+    override fun setMirrorFrontCamera(mirror: Boolean): CameraControllerBuilder {
+        this.mirrorFrontCamera = mirror
+        return this
+    }
 
     override fun setFlashMode(flashMode: FlashMode): CameraControllerBuilder {
         this.flashMode = flashMode
@@ -121,6 +127,7 @@ class AndroidCameraControllerBuilder(private val context: Context, private val l
             returnFilePath = returnFilePath,
             aspectRatio = aspectRatio,
             targetResolution = targetResolution,
+            mirrorFrontCamera = mirrorFrontCamera,
         )
         plugins.forEach {
             it.initialize(cameraController)

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.android.kt
@@ -45,6 +45,7 @@ actual fun rememberCameraKState(
                                 setPreferredCameraDeviceType(config.cameraDeviceType)
                                 setAspectRatio(config.aspectRatio)
                                 setDirectory(config.directory)
+                                setMirrorFrontCamera(config.mirrorFrontCamera)
                                 config.targetResolution?.let { (width, height) ->
                                     setResolution(width, height)
                                 }

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
@@ -395,10 +395,6 @@ actual class CameraController(
     }
 
     /**
-     * Perform fast file-based capture without ByteArray processing.
-     * Directly saves to final destination and returns file path.
-     */
-    /**
      * Capture metadata: mirror the saved image horizontally for the front camera when configured,
      * so the photo matches the mirrored preview (#112).
      */
@@ -407,6 +403,10 @@ actual class CameraController(
             isReversedHorizontal = mirrorFrontCamera && cameraLens == CameraLens.FRONT
         }
 
+    /**
+     * Perform fast file-based capture without ByteArray processing.
+     * Directly saves to final destination and returns file path.
+     */
     private fun performCaptureToFile(continuation: CancellableContinuation<ImageCaptureResult>) {
         // Create final output file directly in desired directory
         val outputFile = createFinalOutputFile()
@@ -564,27 +564,38 @@ actual class CameraController(
                     val originalBitmap = BitmapFactory.decodeFile(tempFile.absolutePath, options)
                     tempFile.delete()
 
-                    // Apply rotation if needed (Samsung device fix)
-                    val rotatedBitmap = if (originalBitmap != null && needsRotation) {
-                        val rotationAngle = when (orientation) {
-                            ExifInterface.ORIENTATION_ROTATE_90 -> 90f
-                            ExifInterface.ORIENTATION_ROTATE_180 -> 180f
-                            ExifInterface.ORIENTATION_ROTATE_270 -> 270f
-                            else -> 0f
+                    // Apply the full EXIF orientation transform. Decoding drops EXIF, so any
+                    // rotation (Samsung fix) AND any mirror flag (front-camera mirroring, #112)
+                    // must be baked into the pixels here or it would be silently lost.
+                    val transformedBitmap = if (originalBitmap != null && needsRotation) {
+                        val matrix = Matrix().apply {
+                            when (orientation) {
+                                ExifInterface.ORIENTATION_ROTATE_90 -> postRotate(90f)
+                                ExifInterface.ORIENTATION_ROTATE_180 -> postRotate(180f)
+                                ExifInterface.ORIENTATION_ROTATE_270 -> postRotate(270f)
+                                ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> postScale(-1f, 1f)
+                                ExifInterface.ORIENTATION_FLIP_VERTICAL -> postScale(1f, -1f)
+                                ExifInterface.ORIENTATION_TRANSPOSE -> {
+                                    postRotate(90f)
+                                    postScale(-1f, 1f)
+                                }
+                                ExifInterface.ORIENTATION_TRANSVERSE -> {
+                                    postRotate(270f)
+                                    postScale(-1f, 1f)
+                                }
+                            }
                         }
 
-                        if (rotationAngle != 0f) {
-                            Matrix().apply { postRotate(rotationAngle) }.let { matrix ->
-                                Bitmap.createBitmap(
-                                    originalBitmap,
-                                    0,
-                                    0,
-                                    originalBitmap.width,
-                                    originalBitmap.height,
-                                    matrix,
-                                    true,
-                                ).also { originalBitmap.recycle() }
-                            }
+                        if (!matrix.isIdentity) {
+                            Bitmap.createBitmap(
+                                originalBitmap,
+                                0,
+                                0,
+                                originalBitmap.width,
+                                originalBitmap.height,
+                                matrix,
+                                true,
+                            ).also { originalBitmap.recycle() }
                         } else {
                             originalBitmap
                         }
@@ -593,7 +604,7 @@ actual class CameraController(
                     }
 
                     // Convert format and compress
-                    rotatedBitmap?.compressToByteArray(
+                    transformedBitmap?.compressToByteArray(
                         format = when (imageFormat) {
                             ImageFormat.JPEG -> Bitmap.CompressFormat.JPEG
                             ImageFormat.PNG -> Bitmap.CompressFormat.PNG

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
@@ -83,6 +83,7 @@ actual class CameraController(
     internal var aspectRatio: AspectRatio,
     internal var plugins: MutableList<CameraPlugin>,
     internal var targetResolution: Pair<Int, Int>? = null,
+    internal var mirrorFrontCamera: Boolean = false,
 ) {
 
     private var cameraProvider: ProcessCameraProvider? = null
@@ -397,10 +398,20 @@ actual class CameraController(
      * Perform fast file-based capture without ByteArray processing.
      * Directly saves to final destination and returns file path.
      */
+    /**
+     * Capture metadata: mirror the saved image horizontally for the front camera when configured,
+     * so the photo matches the mirrored preview (#112).
+     */
+    private fun captureMetadata(): ImageCapture.Metadata =
+        ImageCapture.Metadata().apply {
+            isReversedHorizontal = mirrorFrontCamera && cameraLens == CameraLens.FRONT
+        }
+
     private fun performCaptureToFile(continuation: CancellableContinuation<ImageCaptureResult>) {
         // Create final output file directly in desired directory
         val outputFile = createFinalOutputFile()
-        val outputOptions = ImageCapture.OutputFileOptions.Builder(outputFile).build()
+        val outputOptions =
+            ImageCapture.OutputFileOptions.Builder(outputFile).setMetadata(captureMetadata()).build()
 
         imageCapture?.takePicture(
             outputOptions,
@@ -432,7 +443,8 @@ actual class CameraController(
      * Perform the actual image capture with constant quality
      */
     private fun performCapture(continuation: CancellableContinuation<ImageCaptureResult>, quality: Int) {
-        val outputOptions = ImageCapture.OutputFileOptions.Builder(createTempFile()).build()
+        val outputOptions =
+            ImageCapture.OutputFileOptions.Builder(createTempFile()).setMetadata(captureMetadata()).build()
 
         imageCapture?.takePicture(
             outputOptions,

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/builder/IOSCameraControllerBuilder.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/builder/IOSCameraControllerBuilder.kt
@@ -27,7 +27,13 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
     private var returnFilePath: Boolean = false
     private var aspectRatio: AspectRatio = AspectRatio.RATIO_4_3
     private var targetResolution: Pair<Int, Int>? = null
+    private var mirrorFrontCamera: Boolean = false
     private val plugins = mutableListOf<CameraPlugin>()
+
+    override fun setMirrorFrontCamera(mirror: Boolean): CameraControllerBuilder {
+        this.mirrorFrontCamera = mirror
+        return this
+    }
 
     override fun setFlashMode(flashMode: FlashMode): CameraControllerBuilder {
         this.flashMode = flashMode
@@ -113,6 +119,7 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
             returnFilePath = returnFilePath,
             aspectRatio = aspectRatio,
             targetResolution = targetResolution,
+            mirrorFrontCamera = mirrorFrontCamera,
         )
 
         return cameraController

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.apple.kt
@@ -37,6 +37,7 @@ actual fun rememberCameraKState(
                             setPreferredCameraDeviceType(config.cameraDeviceType)
                             setAspectRatio(config.aspectRatio)
                             setDirectory(config.directory)
+                            setMirrorFrontCamera(config.mirrorFrontCamera)
                             config.targetResolution?.let { (width, height) ->
                                 setResolution(width, height)
                             }

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -80,6 +80,7 @@ actual class CameraController(
     internal var returnFilePath: Boolean,
     internal var plugins: MutableList<CameraPlugin>,
     internal var targetResolution: Pair<Int, Int>? = null,
+    internal var mirrorFrontCamera: Boolean = false,
 ) : UIViewController(null, null) {
     private var isCapturing = atomic(false)
     private val customCameraController = CustomCameraController(
@@ -87,6 +88,7 @@ actual class CameraController(
         initialCameraLens = cameraLens,
         aspectRatio = aspectRatio,
         targetResolution = targetResolution,
+        mirrorFrontCamera = mirrorFrontCamera,
     )
     private var imageCaptureListeners = mutableListOf<(ByteArray) -> Unit>()
     private var metadataOutput = AVCaptureMetadataOutput()

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
@@ -37,6 +37,7 @@ class CustomCameraController(
     private var initialCameraLens: CameraLens = CameraLens.BACK,
     private val aspectRatio: AspectRatio = AspectRatio.RATIO_4_3,
     private val targetResolution: Pair<Int, Int>? = null,
+    private val mirrorFrontCamera: Boolean = false,
 ) : NSObject(),
     AVCapturePhotoCaptureDelegateProtocol {
     var captureSession: AVCaptureSession? = null
@@ -502,6 +503,11 @@ class CustomCameraController(
         photoOutput?.connectionWithMediaType(AVMediaTypeVideo)?.let { connection ->
             if (connection.isVideoOrientationSupported()) {
                 connection.videoOrientation = currentVideoOrientation()
+            }
+            // Mirror the front-camera photo to match the mirrored preview when configured (#112).
+            if (connection.isVideoMirroringSupported()) {
+                connection.automaticallyAdjustsVideoMirroring = false
+                connection.videoMirrored = mirrorFrontCamera && isUsingFrontCamera
             }
         }
 

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.kt
@@ -79,4 +79,10 @@ interface CameraControllerBuilder {
      * Platforms may fall back to the closest supported resolution if an exact match is unavailable.
      */
     fun setResolution(width: Int, height: Int): CameraControllerBuilder
+
+    /**
+     * When true, front-camera captures are horizontally mirrored to match the mirrored preview.
+     * No effect on the back camera. Defaults to a no-op on platforms without a front/back lens.
+     */
+    fun setMirrorFrontCamera(mirror: Boolean): CameraControllerBuilder = this
 }

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/state/CameraKState.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/state/CameraKState.kt
@@ -238,6 +238,8 @@ sealed class CameraKEvent {
  * @property targetResolution Target resolution (width x height) or null for auto.
  * @property directory Directory for saving captured images.
  * @property returnFilePath If true, returns file path instead of byte array (faster).
+ * @property mirrorFrontCamera If true, front-camera captures are horizontally mirrored to match
+ *   the mirrored preview (selfie "what you see is what you get"). No effect on the back camera.
  *
  * @example
  * ```kotlin
@@ -263,4 +265,5 @@ data class CameraConfiguration(
     val targetResolution: Pair<Int, Int>? = null,
     val directory: Directory = Directory.PICTURES,
     val returnFilePath: Boolean = true,
+    val mirrorFrontCamera: Boolean = false,
 )

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/state/CameraKState.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/state/CameraKState.kt
@@ -240,6 +240,9 @@ sealed class CameraKEvent {
  * @property returnFilePath If true, returns file path instead of byte array (faster).
  * @property mirrorFrontCamera If true, front-camera captures are horizontally mirrored to match
  *   the mirrored preview (selfie "what you see is what you get"). No effect on the back camera.
+ *   Representation note: iOS and the Android byte-array path bake the flip into the pixels; the
+ *   Android file path (`takePictureToFile`, the fast path) records it as an EXIF orientation tag,
+ *   which EXIF-aware viewers honor but raw-pixel consumers may ignore.
  *
  * @example
  * ```kotlin

--- a/cameraK/src/commonTest/kotlin/com/kashif/cameraK/state/CameraStateVideoTest.kt
+++ b/cameraK/src/commonTest/kotlin/com/kashif/cameraK/state/CameraStateVideoTest.kt
@@ -123,4 +123,19 @@ class CameraStateVideoTest {
         val b = CameraKEvent.RecordingStopped(result)
         assertEquals(a, b)
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // CameraConfiguration Tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    fun cameraConfiguration_mirrorFrontCameraDefaultsToFalse() {
+        assertFalse(CameraConfiguration().mirrorFrontCamera)
+    }
+
+    @Test
+    fun cameraConfiguration_mirrorFrontCameraPropagates() {
+        assertTrue(CameraConfiguration(mirrorFrontCamera = true).mirrorFrontCamera)
+        assertTrue(CameraConfiguration().copy(mirrorFrontCamera = true).mirrorFrontCamera)
+    }
 }

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.desktop.kt
@@ -31,6 +31,7 @@ actual fun rememberCameraKState(
                         .apply {
                             setImageFormat(config.imageFormat)
                             setDirectory(config.directory)
+                            setMirrorFrontCamera(config.mirrorFrontCamera)
                             config.targetResolution?.let { (width, height) ->
                                 setResolution(width, height)
                             }


### PR DESCRIPTION
Closes #112.

Adds an opt-in `CameraConfiguration.mirrorFrontCamera` (default `false`). When enabled, **front-camera captures are horizontally mirrored** to match the mirrored preview — the common selfie "what you see is what you get" behavior. No effect on the back camera.

## Implementation
- **common:** `CameraConfiguration.mirrorFrontCamera`; `CameraControllerBuilder.setMirrorFrontCamera(...)` with a **default no-op** so platforms without a front/back lens (and external implementers) don't break.
- **Android:** sets `ImageCapture.Metadata.isReversedHorizontal = mirrorFrontCamera && lens == FRONT` on both capture paths. The ByteArray slow path (PNG / memory pressure) now bakes the full EXIF orientation — rotation **and** flip — into the pixels, so the mirror survives the decode/re-encode.
- **iOS:** sets the photo-output `AVCaptureConnection.videoMirrored` for the front camera at capture (`automaticallyAdjustsVideoMirroring = false`); recomputed each capture so lens switching stays correct.
- **Desktop:** inherits the no-op default (no front/back lens concept).
- Wired through all three `rememberCameraKState` builders.

## Usage
```kotlin
val state by rememberCameraKState(
    config = CameraConfiguration(cameraLens = CameraLens.FRONT, mirrorFrontCamera = true),
)
```
