### PR TITLE
Address post-merge Copilot review of #133

### DIFF
--- a/ImageSaverPlugin/src/main/java/com/kashif/imagesaverplugin/ImageSaverPlugin.android.kt
+++ b/ImageSaverPlugin/src/main/java/com/kashif/imagesaverplugin/ImageSaverPlugin.android.kt
@@ -8,6 +8,7 @@ import coil3.PlatformContext
 import com.kashif.cameraK.utils.CameraKLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -80,12 +81,18 @@ class AndroidImageSaverPlugin(private val context: Context, config: ImageSaverCo
 
     override fun getByteArrayFrom(path: String): ByteArray {
         try {
+            // takePictureToFile() returns a raw filesystem path; the image saver may hand back a
+            // content:// URI. Support both: read a plain file directly, otherwise via the resolver.
+            val file = File(path)
+            if (file.exists()) {
+                return file.readBytes()
+            }
             val uri = Uri.parse(path)
             return context.contentResolver.openInputStream(uri)?.use { inputStream ->
                 inputStream.readBytes()
             } ?: throw IOException("Failed to open input stream")
         } catch (e: Exception) {
-            throw IOException("Failed to read image from URI: $path", e)
+            throw IOException("Failed to read image from path/URI: $path", e)
         }
     }
 

--- a/Sample/build.gradle.kts
+++ b/Sample/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
 
         mobileMain.dependencies {
             implementation(libs.kflite)
+            implementation(libs.atomicfu)
         }
 
         androidMain {

--- a/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
+++ b/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.launch
 import org.kmp.playground.kflite.DelegateType
 import org.kmp.playground.kflite.InterpreterOptions
 import org.kmp.playground.kflite.Kflite
+import kotlinx.atomicfu.atomic
 import org.kmp.playground.kflite.bytesToScaledByteBuffer
-import kotlin.concurrent.Volatile
 import kotlin.math.floor
 
 const val FLOAT_TYPE_SIZE = 3
@@ -18,18 +18,18 @@ private const val SCORE_THRESHOLD = 0.4f
 
 // The model is initialized once and reused; inference runs off the main thread, and a new frame is
 // dropped while one is already in flight (the analyzer produces frames far faster than inference).
-@Volatile private var modelReady = false
-@Volatile private var inferenceInFlight = false
+private val modelReady = atomic(false)
+private val inferenceInFlight = atomic(false)
 
 actual fun getTFliteRunner(): (ByteArray.(CoroutineScope) -> Unit)? = ByteArray::runTFliteModel
 
 fun ByteArray.runTFliteModel(scope: CoroutineScope) {
-    if (inferenceInFlight) return
-    inferenceInFlight = true
+    // Atomic check+set so only one inference is ever in flight even if frames arrive concurrently.
+    if (!inferenceInFlight.compareAndSet(expect = false, update = true)) return
     val frame = this
     scope.launch(Dispatchers.Default) {
         try {
-            if (!modelReady) {
+            if (!modelReady.value) {
                 Kflite.init(
                     model = Res.readBytes("files/efficientdet-lite2.tflite"),
                     options = InterpreterOptions(
@@ -38,7 +38,7 @@ fun ByteArray.runTFliteModel(scope: CoroutineScope) {
                         allowFp16PrecisionForFp32 = true,
                     ),
                 )
-                modelReady = true
+                modelReady.value = true
             }
 
             val inputWidth = Kflite.getInputTensor(0).shape[1]
@@ -67,7 +67,7 @@ fun ByteArray.runTFliteModel(scope: CoroutineScope) {
         } catch (e: Exception) {
             // Frame couldn't be processed (e.g. undecodable bytes) — skip it rather than crash.
         } finally {
-            inferenceInFlight = false
+            inferenceInFlight.value = false
         }
     }
 }

--- a/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
+++ b/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
@@ -27,7 +27,7 @@ fun ByteArray.runTFliteModel(scope: CoroutineScope) {
     // Atomic check+set so only one inference is ever in flight even if frames arrive concurrently.
     if (!inferenceInFlight.compareAndSet(expect = false, update = true)) return
     val frame = this
-    scope.launch(Dispatchers.Default) {
+    val job = scope.launch(Dispatchers.Default) {
         try {
             if (!modelReady.value) {
                 Kflite.init(
@@ -66,10 +66,11 @@ fun ByteArray.runTFliteModel(scope: CoroutineScope) {
             printDetections(outputs)
         } catch (e: Exception) {
             // Frame couldn't be processed (e.g. undecodable bytes) — skip it rather than crash.
-        } finally {
-            inferenceInFlight.value = false
         }
     }
+    // Reset via invokeOnCompletion so the flag is cleared even if the scope was already cancelled
+    // and the block never ran (otherwise it would stay true and drop every future frame).
+    job.invokeOnCompletion { inferenceInFlight.value = false }
 }
 
 /**

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/utils/Extensions.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/utils/Extensions.kt
@@ -72,7 +72,10 @@ private fun ImageProxy.yuv420888ToNv21(): ByteArray {
     val ySize = width * height
     val nv21 = ByteArray(ySize + ySize / 2)
 
-    val yBuffer = planes[0].buffer
+    // Duplicate so the bulk read below doesn't advance the shared plane buffer — the same
+    // ImageProxy is handed to every registered analyzer, so mutating its position corrupts
+    // the others. The strided/chroma reads use absolute get(index) and never mutate position.
+    val yBuffer = planes[0].buffer.duplicate()
     val yRowStride = planes[0].rowStride
     val yPixelStride = planes[0].pixelStride
     var pos = 0

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/utils/Extensions.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/utils/Extensions.kt
@@ -74,8 +74,9 @@ private fun ImageProxy.yuv420888ToNv21(): ByteArray {
 
     // Duplicate so the bulk read below doesn't advance the shared plane buffer — the same
     // ImageProxy is handed to every registered analyzer, so mutating its position corrupts
-    // the others. The strided/chroma reads use absolute get(index) and never mutate position.
-    val yBuffer = planes[0].buffer.duplicate()
+    // the others. Rewind the copy so the read starts at 0 regardless of the original's position.
+    // The strided/chroma reads use absolute get(index) and never depend on position.
+    val yBuffer = planes[0].buffer.duplicate().apply { rewind() }
     val yRowStride = planes[0].rowStride
     val yPixelStride = planes[0].pixelStride
     var pos = 0

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -437,6 +437,7 @@ actual class CameraController(
     actual fun getPreferredCameraDeviceType(): CameraDeviceType = cameraDeviceType
 
     actual fun setPreferredCameraDeviceType(deviceType: CameraDeviceType) {
+        if (cameraDeviceType == deviceType) return // avoid a redundant AVCaptureSession input swap
         cameraDeviceType = deviceType
         customCameraController.switchToDeviceType(deviceType)
     }

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
@@ -75,10 +75,7 @@ actual class CameraController(
 
             return@withContext try {
                 val ext = if (imageFormat == ImageFormat.PNG) "png" else "jpg"
-                val outFile = File(
-                    System.getProperty("java.io.tmpdir"),
-                    "CameraK_${System.currentTimeMillis()}.$ext",
-                )
+                val outFile = File.createTempFile("CameraK_", ".$ext")
                 ImageIO.write(currentImage, ext, outFile)
                 listener(outFile.readBytes())
                 ImageCaptureResult.SuccessWithFile(outFile.absolutePath)

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
@@ -27,7 +27,6 @@ import org.bytedeco.javacv.FFmpegFrameRecorder
 import org.bytedeco.javacv.FrameGrabber
 import org.bytedeco.javacv.Java2DFrameConverter
 import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -74,16 +73,18 @@ actual class CameraController(
                 return@withContext ImageCaptureResult.Error(IllegalStateException("No image available"))
             }
 
-            val outputStream = ByteArrayOutputStream()
             return@withContext try {
-                ImageIO.write(currentImage, "jpg", outputStream)
-                listener(outputStream.toByteArray())
-                ImageCaptureResult.Success(outputStream.toByteArray())
+                val ext = if (imageFormat == ImageFormat.PNG) "png" else "jpg"
+                val outFile = File(
+                    System.getProperty("java.io.tmpdir"),
+                    "CameraK_${System.currentTimeMillis()}.$ext",
+                )
+                ImageIO.write(currentImage, ext, outFile)
+                listener(outFile.readBytes())
+                ImageCaptureResult.SuccessWithFile(outFile.absolutePath)
             } catch (e: Exception) {
                 CameraKLogger.e("CameraK", "Unhandled exception", e)
                 ImageCaptureResult.Error(e)
-            } finally {
-                outputStream.close()
             }
         }
     }


### PR DESCRIPTION
Copilot reviewed #133 after it merged; this fixes the issues it raised.

| # | Finding | Fix |
|---|---------|-----|
| 1 | **Android analyzer mutated the shared `ImageProxy` buffer** — the bulk Y read advanced the buffer position; since the same frame is fed to every registered analyzer, the others could under-read | Read from a `duplicate()` of the Y plane buffer (chroma reads were already absolute/side-effect-free) |
| 2 | Desktop `takePictureToFile()` returned in-memory bytes despite its name | Writes the JPEG/PNG to a file and returns `SuccessWithFile` |
| 3 | TFLite demo `inferenceInFlight` check+set wasn't atomic | `atomic` + `compareAndSet` (and `atomic` `modelReady`) |
| 4 | iOS `setPreferredCameraDeviceType` had no "already active" guard → redundant `AVCaptureSession` input swap on every controller re-create | Early-return when unchanged (matches Android) |
| 5 | README manual-save example: `getByteArrayFrom` only handled `content://` URIs, but `takePictureToFile()` returns a filesystem path on Android | `getByteArrayFrom` now reads a raw file path directly, falling back to the resolver |

## Verification
- Compiles on Android + Desktop + iOS; `:cameraK:desktopTest` passes.