### PR TITLE
Docs: rename CameraK→Kamera, fix broken API examples, bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,52 +1,36 @@
 # Changelog
 
-All notable changes to the CameraK project will be documented in this file.
+All notable changes to the Kamera project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-- **Plugin Initialization Timing (#52)**: Fixed plugins attempting to initialize before camera is ready
-  - Added null checks in `QRScannerPlugin.android.kt` to prevent crashes when `cameraProvider` is null
-  - Wrapped `OcrPlugin.onAttach()` in try-catch to gracefully handle initialization failures
-  - Made OCR plugin fail silently (with warning logs) if tessdata not found instead of crashing the app
-  - Added validation to ensure camera is fully bound before updating image analyzer
-
-- **Desktop Tesseract Path Resolution (#51)**: Fixed hardcoded tessdata path breaking on other machines
-  - Implemented dynamic path resolution checking multiple locations for tessdata files
-  - Added graceful degradation when tessdata is not found on desktop
-  - Desktop app now runs without OCR errors even when tessdata is unavailable
-
-- **Desktop QR Scanner Syntax Error (#50)**: Fixed duplicate `put()` statement in decode hints map
-  - Corrected malformed EnumMap initialization in QRScannerPlugin
-
 ### Added
-- **API Toggle Feature**: Added UI toggle button to switch between new and old camera APIs
-  - New Compose-first `CameraKScreen` with reactive state management
-  - Legacy callback-based `CameraPreview` API available via toggle
-  - Both APIs work seamlessly with all plugins (ImageSaver, QRScanner, OCR)
-  - Toggle button in camera controls bottom sheet for easy switching
+- **Opt-in logging (`CameraKLogger`)** (#133): internal logging is now disabled by default and routed through `CameraKLogger`. Set `CameraKLogger.enabled = true` to turn it on, or provide a custom `CameraKLogger.sink` to forward logs to your own logger.
+- **`mirrorFrontCamera` configuration** (#112): optionally mirror front-camera captures to match the mirrored preview. Defaults to `false`. iOS and the Android byte-array path bake the flip into pixels; the Android file path records it as an EXIF orientation tag.
+- **CI build check** (#129): a workflow builds all targets on every PR; merges are gated on passing checks and resolved review conversations.
 
-- **iOS Image Orientation Issue (#44)**: Fixed images being saved in wrong orientation on iOS
-  - Added device orientation detection at photo capture time by setting `videoOrientation` on the photo output connection
-  - Photos captured in portrait mode now save as portrait, landscape photos save as landscape
-  - Optimized image processing to use original `fileDataRepresentation()` when quality is high (>85%), preserving original EXIF orientation metadata
-  - Added `UIImage.fixOrientation()` utility function that applies orientation metadata to pixel data when re-encoding is necessary (format conversion or quality reduction)
-  - Updated `ImageSaverPlugin` to apply orientation correction when saving images to Photos library
-  - Ensured orientation is correctly preserved across portrait, landscape, and upside-down device orientations
+### Changed
+- **Better barcode/QR detection** (#130) on Android and iOS (stride-aware luminance, `TRY_HARDER`, inverted retry).
+- **Android analyzer** now emits decodable JPEG frames (matching iOS) and runs off the main thread, fixing frame backpressure and `Could not decode ByteArray to Bitmap` consumers.
+- **`setPreferredCameraDeviceType()`** now performs a live re-bind instead of requiring reinitialization.
 
-### Technical Details
-The iOS camera implementation previously had an issue where:
-1. Photos were captured with correct EXIF orientation metadata
-2. But when converted from `NSData` → `UIImage` → `JPEG/PNG` data, the orientation was lost or incorrectly applied
+### Removed (breaking)
+- Deprecated `CameraController.takePicture()` (returned `ByteArray`) — use `takePictureToFile()`.
+- Legacy callback-based `CameraPreview` API and the new/old API toggle.
+- Dead `returnFilePath` flag and other removed-API references in docs. See the migration table in the README.
 
-The fix implements a multi-layered approach:
-1. **Capture Level**: Set `videoOrientation` on `AVCapturePhotoOutput` connection before capture to ensure correct EXIF metadata
-2. **Processing Level**: Use original capture data directly when possible (JPEG format with high quality)
-3. **Re-encoding Level**: When format conversion or quality reduction is needed, apply `fixOrientation()` to bake orientation into pixel data
-4. **Save Level**: Apply orientation correction in `ImageSaverPlugin` before saving to Photos library
-
-This ensures images display correctly regardless of how they were captured (portrait, landscape, etc.) and regardless of the output format (JPEG, PNG).
+### Fixed
+- **iOS preview/capture mismatch on flat devices** (#115, #109): preview no longer distorts when the device is face-up.
+- **iOS crash from deprecated video stabilization API** (#113).
+- **Android auto-save after capture**: capture listeners are now fired on `takePictureToFile()`.
+- **Cross-analyzer buffer corruption**: the shared `ImageProxy` Y-plane buffer is duplicated before reads so concurrent analyzers aren't affected.
+- **Desktop `takePictureToFile()`** now writes a real file instead of returning an empty path.
+- **`ImageSaverPlugin.getByteArrayFrom()`** (Android) now reads raw file paths before falling back to `ContentResolver`.
+- **Plugin initialization timing** (#52): null checks and graceful failure when the camera isn't ready yet.
+- **Desktop Tesseract path resolution** (#51): dynamic tessdata lookup with graceful degradation.
+- **Desktop QR scanner** (#50): fixed malformed decode-hints `EnumMap` initialization.
+- **iOS image orientation** (#44): captures save in the correct orientation across portrait, landscape, and upside-down.
 

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
-# CameraK
+# Kamera
 
 <p align="center">
-  <img src="docs/assets/kamera.jpg" alt="CameraK Poster" width="800" style="border-radius: 50%;"/>
+  <img src="docs/assets/kamera.jpg" alt="Kamera Poster" width="800" style="border-radius: 50%;"/>
 </p>
 
 <p align="center">
@@ -11,7 +11,7 @@ A modern camera library for Compose Multiplatform supporting Android, iOS, and D
 <p align="center">
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.kashif-mehmood-km/camerak?label=Maven%20Central&color=blue)](https://search.maven.org/search?q=g:io.github.kashif-mehmood-km)
-[![GitHub Release](https://img.shields.io/github/v/release/kashif-e/camerak)](https://github.com/Kashif-E/CameraK/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/kashif-e/Kamera)](https://github.com/Kashif-E/Kamera/releases)
 [![Kotlin Weekly](https://img.shields.io/badge/Kotlin_Weekly-425-7F52FF)](https://mailchi.mp/kotlinweekly/kotlin-weekly-425)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 </p>
@@ -34,14 +34,14 @@ Add dependencies to your `build.gradle.kts`:
 ```kotlin
 dependencies {
     // Core library
-    implementation("io.github.kashif-mehmood-km:camerak:0.2.0")
+    implementation("io.github.kashif-mehmood-km:camerak:0.4")
 
     // Optional plugins
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.2.0")
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.2.0")
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.2.0")
-    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:0.3")
-    implementation("io.github.kashif-mehmood-km:analyzer_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:analyzer_plugin:0.4")
 }
 ```
 
@@ -51,14 +51,14 @@ Add to your `libs.versions.toml`:
 
 ```toml
 [versions]
-camerak = "0.2.0"
+camerak = "0.4"
 
 [libraries]
 camerak = { module = "io.github.kashif-mehmood-km:camerak", version.ref = "camerak" }
 camerak-image-saver = { module = "io.github.kashif-mehmood-km:image_saver_plugin", version.ref = "camerak" }
 camerak-qr-scanner = { module = "io.github.kashif-mehmood-km:qr_scanner_plugin", version.ref = "camerak" }
 camerak-ocr = { module = "io.github.kashif-mehmood-km:ocr_plugin", version.ref = "camerak" }
-camerak-analyzer = { module = "io.github.kashif-mehmood-km:analzer_plugin", version.ref = "camerak" }
+camerak-analyzer = { module = "io.github.kashif-mehmood-km:analyzer_plugin", version.ref = "camerak" }
 camerak-video-recorder = { module = "io.github.kashif-mehmood-km:video_recorder_plugin", version.ref = "camerak" }
 ```
 
@@ -230,10 +230,12 @@ val cameraState by rememberCameraKState(
         // Image output
         imageFormat = ImageFormat.JPEG,          // JPEG or PNG
         directory = Directory.PICTURES,         // PICTURES, DCIM, DOCUMENTS
-        returnFilePath = true,
 
         // Quality
         qualityPrioritization = QualityPrioritization.BALANCED,
+
+        // Mirror front-camera captures to match the preview (Android/iOS)
+        mirrorFrontCamera = false,
 
         // iOS only: Advanced camera device types
         cameraDeviceType = CameraDeviceType.DEFAULT,
@@ -258,8 +260,8 @@ val cameraState by rememberCameraKState(
 | `torchMode` | `TorchMode` | `OFF` | ON, OFF, or AUTO |
 | `imageFormat` | `ImageFormat` | `JPEG` | JPEG or PNG |
 | `directory` | `Directory` | `PICTURES` | PICTURES, DCIM, or DOCUMENTS |
-| `returnFilePath` | `Boolean` | `true` | Whether to return file path in capture result |
 | `qualityPrioritization` | `QualityPrioritization` | `BALANCED` | Capture quality vs speed tradeoff |
+| `mirrorFrontCamera` | `Boolean` | `false` | Mirror front-camera captures to match preview (Android/iOS) |
 | `cameraDeviceType` | `CameraDeviceType` | `DEFAULT` | iOS: DEFAULT, WIDE_ANGLE, ULTRA_WIDE, TELEPHOTO, MACRO |
 
 ### Camera Runtime Control
@@ -494,24 +496,25 @@ ocrPlugin.stopRecognition()
 
 ### Analyzer Plugin
 
-Image Aalyzer - observe latest frame in a thread safe environment. Results are delivered through `CameraKEvent.LatestFrame` events via the `events` SharedFlow on `CameraKStateHolder`.
+Image Analyzer - observe the latest frame (as JPEG-encoded `ByteArray`) in a thread-safe environment. Frames are delivered through the plugin's `getAnalyzerFlow()`.
 
 #### Setup
 
 ```kotlin
-val scope = rememberCoroutineScope()
-val analyzerPlugin = remember { AnalyzerPlugin(scope) }
+val analyzerPlugin = rememberAnalyzerPlugin()
 var latestFrame by remember { mutableStateOf<ByteArray?>(null) }
 
-val cameraState by rememberCameraKState(-> stateHolder
-    analyzerPlugin.attachToStateHolder(stateHolder)
+val cameraState by rememberCameraKState(
+    setupPlugins = { stateHolder ->
+        stateHolder.attachPlugin(analyzerPlugin)
+    },
 )
 
-// Observe latest frame events
+// Observe the latest frame
 LaunchedEffect(analyzerPlugin) {
-    analyzerPlugin.getAnalyzerFlow().collect{-> frame
-	latestFrame = frame
-  }
+    analyzerPlugin.getAnalyzerFlow().collect { frame ->
+        latestFrame = frame
+    }
 }
 ```
 
@@ -972,22 +975,22 @@ LaunchedEffect(Unit) {
 
 **Problem**: Text recognition accuracy low on camera stream.
 
-**Solution**: Use high-resolution images for recognition:
+**Solution**: Text recognition runs on the live camera stream. Recognized text is delivered through `ocrPlugin.ocrFlow` (and as `CameraKEvent.TextRecognized` on `stateHolder.events`). For better accuracy, hold the camera steady and move closer so the text fills more of the frame:
 
 ```kotlin
-// Better accuracy - from captured image
-scope.launch {
-    when (val result = controller.takePictureToFile()) {
-        is ImageCaptureResult.SuccessWithFile -> {
-            val file = File(result.filePath)
-            val byteArray = file.readBytes()
-            val text = ocrPlugin.recognizeText(byteArray)
-        }
+// Recognized text is delivered on the OCR flow
+LaunchedEffect(ocrPlugin) {
+    for (text in ocrPlugin.ocrFlow) {
+        recognizedText = text
     }
 }
 
-// Lower accuracy - real-time stream
-// Text recognized events auto-delivered via stateHolder.events
+// Or observe TextRecognized events via the state holder
+LaunchedEffect(stateHolder) {
+    stateHolder.events.collect { event ->
+        if (event is CameraKEvent.TextRecognized) recognizedText = event.text
+    }
+}
 ```
 
 #### Compilation errors with plugins
@@ -998,10 +1001,10 @@ scope.launch {
 
 ```gradle
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.2.0")
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.2.0")
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.2.0")
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.2.0")
+    implementation("io.github.kashif-mehmood-km:camerak:0.4")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -496,7 +496,7 @@ ocrPlugin.stopRecognition()
 
 ### Analyzer Plugin
 
-Image Analyzer - observe the latest frame (as JPEG-encoded `ByteArray`) in a thread-safe environment. Frames are delivered through the plugin's `getAnalyzerFlow()`.
+Image Analyzer - observe the latest frame as a `ByteArray` in a thread-safe environment. Frames are delivered through the plugin's `getAnalyzerFlow()`. The byte layout is platform-dependent: JPEG-encoded on Android and iOS, raw pixel bytes (`DataBufferByte`) on Desktop — decode accordingly.
 
 #### Setup
 

--- a/README.MD
+++ b/README.MD
@@ -975,20 +975,13 @@ LaunchedEffect(Unit) {
 
 **Problem**: Text recognition accuracy low on camera stream.
 
-**Solution**: Text recognition runs on the live camera stream. Recognized text is delivered through `ocrPlugin.ocrFlow` (and as `CameraKEvent.TextRecognized` on `stateHolder.events`). For better accuracy, hold the camera steady and move closer so the text fills more of the frame:
+**Solution**: Text recognition runs on the live camera stream. Recognized text is delivered through `ocrPlugin.ocrFlow` (and also emitted as a `CameraKEvent.TextRecognized` event for anyone collecting the state holder's `events`). For better accuracy, hold the camera steady and move closer so the text fills more of the frame:
 
 ```kotlin
 // Recognized text is delivered on the OCR flow
 LaunchedEffect(ocrPlugin) {
     for (text in ocrPlugin.ocrFlow) {
         recognizedText = text
-    }
-}
-
-// Or observe TextRecognized events via the state holder
-LaunchedEffect(stateHolder) {
-    stateHolder.events.collect { event ->
-        if (event is CameraKEvent.TextRecognized) recognizedText = event.text
     }
 }
 ```

--- a/docs/api/camera-k-screen.md
+++ b/docs/api/camera-k-screen.md
@@ -20,9 +20,11 @@ Convenience wrapper composable that simplifies camera state handling with automa
 fun CameraKScreen(
     modifier: Modifier = Modifier,
     cameraState: CameraKState,
+    deviceOrientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
     loadingContent: @Composable () -> Unit = { DefaultLoadingScreen() },
     errorContent: @Composable (CameraKState.Error) -> Unit = { DefaultErrorScreen(it) },
     showPreview: Boolean = true,
+    overlay: @Composable (CameraPreviewScope.() -> Unit)? = null,
     content: @Composable (CameraKState.Ready) -> Unit
 )
 ```
@@ -50,6 +52,22 @@ Whether to automatically show camera preview when ready.
 
 - `true` (default) -- Preview shown automatically in background
 - `false` -- No preview, useful for custom preview implementations
+
+### deviceOrientation
+
+```kotlin
+deviceOrientation: DeviceOrientation = DeviceOrientation.PORTRAIT
+```
+
+Orientation passed to the preview so frames and captures are rotated correctly. One of `PORTRAIT`, `LANDSCAPE_LEFT`, `PORTRAIT_UPSIDE_DOWN`, `LANDSCAPE_RIGHT`.
+
+### overlay
+
+```kotlin
+overlay: @Composable (CameraPreviewScope.() -> Unit)? = null
+```
+
+Optional content drawn on top of the preview (e.g. focus reticles, grids). Receives a `CameraPreviewScope`. Defaults to `null` (no overlay).
 
 ### loadingContent
 
@@ -247,11 +265,13 @@ fun CustomPreviewCamera() {
 ```kotlin
 @Composable
 fun CameraWithPlugins() {
-    val scope = rememberCoroutineScope()
+    // Create plugins in composable scope, then attach them inside setupPlugins.
+    val qrScannerPlugin = rememberQRScannerPlugin()
+    val ocrPlugin = rememberOcrPlugin()
     val cameraState by rememberCameraKState(
         setupPlugins = { stateHolder ->
-            stateHolder.attachPlugin(QRScannerPlugin())
-            stateHolder.attachPlugin(OcrPlugin())
+            stateHolder.attachPlugin(qrScannerPlugin)
+            stateHolder.attachPlugin(ocrPlugin)
         }
     )
 

--- a/docs/api/state-holder.md
+++ b/docs/api/state-holder.md
@@ -27,6 +27,11 @@ expect fun rememberCameraKState(
 **Example:**
 
 ```kotlin
+// Create plugins in composable scope first — the remember…Plugin(...) factories
+// are @Composable and cannot be called inside the setupPlugins lambda.
+val qrScannerPlugin = rememberQRScannerPlugin()
+val ocrPlugin = rememberOcrPlugin()
+
 val cameraState by rememberCameraKState(
     config = CameraConfiguration(
         cameraLens = CameraLens.BACK,
@@ -39,8 +44,6 @@ val cameraState by rememberCameraKState(
     }
 )
 ```
-
-> Create plugins with their `remember…Plugin(...)` factories in composable scope first (e.g. `val qrScannerPlugin = rememberQRScannerPlugin()`), then attach those instances inside `setupPlugins`. The factories are `@Composable` and cannot be called inside the `setupPlugins` lambda.
 
 ## Properties
 

--- a/docs/api/state-holder.md
+++ b/docs/api/state-holder.md
@@ -1,6 +1,6 @@
 # CameraKStateHolder API
 
-Core state management for CameraK. Manages camera lifecycle, exposes reactive state, and handles plugin coordination.
+Core state management for Kamera. Manages camera lifecycle, exposes reactive state, and handles plugin coordination.
 
 ## Overview
 
@@ -34,11 +34,13 @@ val cameraState by rememberCameraKState(
         aspectRatio = AspectRatio.RATIO_16_9
     ),
     setupPlugins = { stateHolder ->
-        stateHolder.attachPlugin(QRScannerPlugin())
-        stateHolder.attachPlugin(OcrPlugin())
+        stateHolder.attachPlugin(qrScannerPlugin)
+        stateHolder.attachPlugin(ocrPlugin)
     }
 )
 ```
+
+> Create plugins with their `remember…Plugin(...)` factories in composable scope first (e.g. `val qrScannerPlugin = rememberQRScannerPlugin()`), then attach those instances inside `setupPlugins`. The factories are `@Composable` and cannot be called inside the `setupPlugins` lambda.
 
 ## Properties
 
@@ -93,6 +95,9 @@ data class CameraUIState(
     val cameraDeviceType: CameraDeviceType = CameraDeviceType.DEFAULT,
     val isCapturing: Boolean = false,
     val lastError: String? = null,
+    val isRecording: Boolean = false,
+    val isPaused: Boolean = false,
+    val recordingDurationMs: Long = 0L,
 )
 ```
 
@@ -123,6 +128,10 @@ sealed class CameraKEvent {
     data class QRCodeScanned(val qrCode: String) : CameraKEvent()
     data class TextRecognized(val text: String) : CameraKEvent()
     data class PermissionDenied(val permission: String) : CameraKEvent()
+    data class RecordingStarted(val filePath: String) : CameraKEvent()
+    data class RecordingStopped(val result: VideoCaptureResult) : CameraKEvent()
+    data class RecordingFailed(val exception: Exception) : CameraKEvent()
+    data class RecordingMaxDurationReached(val filePath: String, val durationMs: Long) : CameraKEvent()
 }
 ```
 
@@ -381,6 +390,7 @@ Cleans up resources. Called automatically when composable leaves composition.
 @Composable
 fun CompleteStateHolderExample() {
     val scope = rememberCoroutineScope()
+    val qrScannerPlugin = rememberQRScannerPlugin()
 
     val cameraState by rememberCameraKState(
         config = CameraConfiguration(
@@ -389,7 +399,7 @@ fun CompleteStateHolderExample() {
             aspectRatio = AspectRatio.RATIO_16_9
         ),
         setupPlugins = { stateHolder ->
-            stateHolder.attachPlugin(QRScannerPlugin())
+            stateHolder.attachPlugin(qrScannerPlugin)
         }
     )
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
-# Contributing to CameraK
+# Contributing to Kamera
 
-Thank you for your interest in contributing to CameraK! This document provides guidelines and steps for contributing.
+Thank you for your interest in contributing to Kamera! This document provides guidelines and steps for contributing.
 
 ## Ways to Contribute
 
@@ -17,7 +17,7 @@ Before creating an issue, please:
 1. **Search existing issues** to avoid duplicates
 2. **Use the issue template** if available
 3. **Provide details**:
-   - CameraK version
+   - Kamera version
    - Platform (Android/iOS/Desktop) and OS version
    - Device/emulator details
    - Minimal reproducible example
@@ -27,7 +27,7 @@ Before creating an issue, please:
 ### Good Issue Example
 
 ```markdown
-**CameraK Version:** 0.3
+**Kamera Version:** 0.3
 **Platform:** Android 13 (Pixel 6)
 
 **Description:**
@@ -60,7 +60,7 @@ E/CameraK: Failed to bind camera...
 
 ### Prerequisites
 
-- JDK 11+
+- JDK 17+
 - Android Studio Hedgehog or later
 - Xcode 14+ (for iOS development)
 - Kotlin 1.9.0+
@@ -68,8 +68,8 @@ E/CameraK: Failed to bind camera...
 ### Clone Repository
 
 ```bash
-git clone https://github.com/Kashif-E/CameraK.git
-cd CameraK
+git clone https://github.com/Kashif-E/Kamera.git
+cd Kamera
 ```
 
 ### Build Project
@@ -331,9 +331,9 @@ Contributors are recognized in:
 
 ## Questions?
 
-- **GitHub Discussions**: [Discussions](https://github.com/Kashif-E/CameraK/discussions)
-- **Issues**: [Issues](https://github.com/Kashif-E/CameraK/issues)
+- **GitHub Discussions**: [Discussions](https://github.com/Kashif-E/Kamera/discussions)
+- **Issues**: [Issues](https://github.com/Kashif-E/Kamera/issues)
 
 ## Thank You!
 
-Your contributions make CameraK better for everyone. We appreciate your time and effort!
+Your contributions make Kamera better for everyone. We appreciate your time and effort!

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ Before creating an issue, please:
 ### Good Issue Example
 
 ```markdown
-**Kamera Version:** 0.3
+**Kamera Version:** 0.4
 **Platform:** Android 13 (Pixel 6)
 
 **Description:**

--- a/docs/examples/android.md
+++ b/docs/examples/android.md
@@ -1,6 +1,6 @@
 # Android Setup
 
-Setup CameraK for Android applications.
+Setup Kamera for Android applications.
 
 ## Requirements
 
@@ -16,7 +16,7 @@ Setup CameraK for Android applications.
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.3")
+    implementation("io.github.kashif-mehmood-km:camerak:0.4")
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 
 ```toml
 [versions]
-camerak = "0.3"
+camerak = "0.4"
 
 [libraries]
 camerak = { module = "io.github.kashif-mehmood-km:camerak", version.ref = "camerak" }
@@ -83,9 +83,9 @@ dependencies {
 
 ## Step 3: Request Permissions
 
-CameraK includes a built-in, cross-platform permission API. No third-party libraries needed.
+Kamera includes a built-in, cross-platform permission API. No third-party libraries needed.
 
-### Using CameraK's Permission API
+### Using Kamera's Permission API
 
 ```kotlin
 @Composable
@@ -223,7 +223,7 @@ If using ProGuard/R8, add rules:
 ### proguard-rules.pro
 
 ```proguard
-# CameraK
+# Kamera
 -keep class com.kashif.cameraK.** { *; }
 -keepclassmembers class com.kashif.cameraK.** { *; }
 
@@ -281,7 +281,7 @@ Test on real device for:
 
 **Cause:** CameraX version conflict.
 
-**Solution:** CameraK includes CameraX automatically -- don't add manual CameraX dependencies.
+**Solution:** Kamera includes CameraX automatically -- don't add manual CameraX dependencies.
 
 ## Platform-Specific Features
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -195,6 +195,32 @@ config = CameraConfiguration(
 - `BALANCED`: General-purpose apps
 - `SPEED`: Burst mode, document scanning
 
+## Front Camera Mirroring
+
+Mirror front-camera captures so a selfie matches the mirrored preview ("what you see is what you get"). No effect on the back camera.
+
+```kotlin
+config = CameraConfiguration(
+    cameraLens = CameraLens.FRONT,
+    mirrorFrontCamera = true  // default: false
+)
+```
+
+**Representation note:** iOS and the Android byte-array path bake the flip into the pixels. The Android file path (`takePictureToFile()`, the fast path) records it as an EXIF orientation tag — EXIF-aware viewers honor it, but raw-pixel consumers may ignore it.
+
+## Logging
+
+Internal logging is off by default. Enable it (e.g. in debug builds) or route it to your own logger via `CameraKLogger`:
+
+```kotlin
+import com.kashif.cameraK.utils.CameraKLogger
+
+CameraKLogger.enabled = true                          // turn on internal logs
+CameraKLogger.sink = { level, tag, msg, throwable ->  // optional: forward to your logger
+    Log.d(tag, "[$level] $msg")
+}
+```
+
 ## Complete Example
 
 ```kotlin
@@ -331,6 +357,7 @@ controller.toggleCameraLens()  // BACK <-> FRONT
 | `directory` | `Directory` | `PICTURES` | All |
 | `qualityPrioritization` | `QualityPrioritization` | `BALANCED` | All |
 | `torchMode` | `TorchMode` | `OFF` | Android, iOS |
+| `mirrorFrontCamera` | `Boolean` | `false` | Android, iOS |
 
 ## Next Steps
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -217,7 +217,7 @@ import com.kashif.cameraK.utils.CameraKLogger
 
 CameraKLogger.enabled = true                          // turn on internal logs
 CameraKLogger.sink = { level, tag, msg, throwable ->  // optional: forward to your logger
-    Log.d(tag, "[$level] $msg")
+    println("[$level] $tag: $msg")                    // e.g. Log.d on Android, os_log on iOS
 }
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Add CameraK to your Kotlin Multiplatform project in under 5 minutes.
+Add Kamera to your Kotlin Multiplatform project in under 5 minutes.
 
 ## Prerequisites
 
@@ -9,7 +9,7 @@ Add CameraK to your Kotlin Multiplatform project in under 5 minutes.
 - Target platforms:
     - **Android**: API 21+ (Android 5.0)
     - **iOS**: iOS 13.0+
-    - **Desktop**: JDK 11+
+    - **Desktop**: JDK 17+
 
 ## Step 1: Add Dependencies
 
@@ -21,7 +21,7 @@ Add to your `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.kashif-mehmood-km:camerak:0.3")
+            implementation("io.github.kashif-mehmood-km:camerak:0.4")
         }
     }
 }
@@ -33,7 +33,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-camerak = "0.3"
+camerak = "0.4"
 
 [libraries]
 camerak = { module = "io.github.kashif-mehmood-km:camerak", version.ref = "camerak" }
@@ -55,7 +55,7 @@ kotlin {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.3")
+    implementation("io.github.kashif-mehmood-km:camerak:0.4")
 }
 ```
 
@@ -105,7 +105,7 @@ Run Gradle sync:
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
 }
 ```
 
@@ -113,7 +113,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
 }
 ```
 
@@ -121,7 +121,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
 }
 ```
 
@@ -135,14 +135,14 @@ fun TestCameraScreen() {
     val cameraState by rememberCameraKState()
 
     when (val state = cameraState) {
-        is CameraKState.Ready -> Text("CameraK is ready!")
+        is CameraKState.Ready -> Text("Kamera is ready!")
         is CameraKState.Error -> Text("Error: ${state.message}")
         CameraKState.Initializing -> CircularProgressIndicator()
     }
 }
 ```
 
-If you see "CameraK is ready!" — you're all set!
+If you see "Kamera is ready!" — you're all set!
 
 ## Troubleshooting
 

--- a/docs/guides/camera-capture.md
+++ b/docs/guides/camera-capture.md
@@ -100,7 +100,9 @@ when (result) {
         // Error occurred
         val error = result.exception
     }
-    else -> {} // Success(byteArray) is not returned by takePictureToFile()
+    is ImageCaptureResult.Success -> {
+        // Not produced by takePictureToFile(); handle defensively
+    }
 }
 ```
 

--- a/docs/guides/camera-capture.md
+++ b/docs/guides/camera-capture.md
@@ -82,13 +82,13 @@ Sealed class ensures exhaustive pattern matching:
 
 ```kotlin
 sealed class ImageCaptureResult {
-    data class SuccessWithFile(val filePath: String) : ImageCaptureResult()
     data class Success(val byteArray: ByteArray) : ImageCaptureResult()
+    data class SuccessWithFile(val filePath: String) : ImageCaptureResult()
     data class Error(val exception: Exception) : ImageCaptureResult()
 }
 ```
 
-**Handle all cases:**
+`takePictureToFile()` only ever returns `SuccessWithFile` or `Error` — the `Success(byteArray)` variant is never produced by it, so handling those two cases is enough:
 
 ```kotlin
 when (result) {
@@ -96,14 +96,11 @@ when (result) {
         // File saved, path available
         val path = result.filePath
     }
-    is ImageCaptureResult.Success -> {
-        // ByteArray available (deprecated path)
-        val data = result.byteArray
-    }
     is ImageCaptureResult.Error -> {
         // Error occurred
         val error = result.exception
     }
+    else -> {} // Success(byteArray) is not returned by takePictureToFile()
 }
 ```
 
@@ -352,7 +349,7 @@ scope.launch {
 
 ## Performance Tips
 
-1. **Use `takePictureToFile()`** — 2-3x faster than `takePicture()`
+1. **Use `takePictureToFile()`** — direct file capture avoids holding the full image in memory
 2. **Lower resolution** — Set `targetResolution` in `CameraConfiguration` for faster capture
 3. **JPEG format** — Faster than PNG
 4. **Quality prioritization** — Use `QualityPrioritization.SPEED` for rapid capture

--- a/docs/guides/camera-capture.md
+++ b/docs/guides/camera-capture.md
@@ -88,7 +88,7 @@ sealed class ImageCaptureResult {
 }
 ```
 
-`takePictureToFile()` only ever returns `SuccessWithFile` or `Error` — the `Success(byteArray)` variant is never produced by it, so handling those two cases is enough:
+`takePictureToFile()` only ever returns `SuccessWithFile` or `Error` — the `Success(byteArray)` variant is never produced by it. Since `ImageCaptureResult` is a sealed class, the `when` must still be exhaustive, so keep a `Success` branch as defensive handling (it simply won't be hit for this API):
 
 ```kotlin
 when (result) {

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,6 +1,6 @@
 # Plugins
 
-Extend CameraK with modular plugins for QR scanning, OCR, and custom processing.
+Extend Kamera with modular plugins for QR scanning, OCR, and custom processing.
 
 ## Overview
 
@@ -16,12 +16,18 @@ Plugins extend camera functionality without modifying core camera code. They aut
 Add plugins during initialization via `setupPlugins`:
 
 ```kotlin
+// Create plugins in composable scope first — the remember…Plugin(...) factories are
+// @Composable and cannot be called inside the setupPlugins lambda.
+val qrScannerPlugin = rememberQRScannerPlugin()
+val ocrPlugin = rememberOcrPlugin()
+val imageSaverPlugin = rememberImageSaverPlugin(config = ImageSaverConfig(isAutoSave = true))
+
 val cameraState by rememberCameraKState(
     config = CameraConfiguration(),
     setupPlugins = { stateHolder ->
-        stateHolder.attachPlugin(rememberQRScannerPlugin())
-        stateHolder.attachPlugin(rememberOcrPlugin())
-        stateHolder.attachPlugin(rememberImageSaverPlugin())
+        stateHolder.attachPlugin(qrScannerPlugin)
+        stateHolder.attachPlugin(ocrPlugin)
+        stateHolder.attachPlugin(imageSaverPlugin)
     }
 )
 ```
@@ -34,7 +40,7 @@ Plugins activate automatically when camera reaches `Ready` state.
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
 }
 ```
 
@@ -108,7 +114,7 @@ fun QRScannerScreen() {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
 }
 ```
 
@@ -182,24 +188,23 @@ fun OCRScannerScreen() {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
 }
 ```
 
 ### Usage
 
 ```kotlin
+val imageSaverPlugin = rememberImageSaverPlugin(
+    config = ImageSaverConfig(
+        isAutoSave = true,  // Auto-save every capture
+        directory = Directory.PICTURES
+    )
+)
 val cameraState by rememberCameraKState(
     config = CameraConfiguration(),
     setupPlugins = { stateHolder ->
-        stateHolder.attachPlugin(
-            rememberImageSaverPlugin(
-                config = ImageSaverConfig(
-                    isAutoSave = true,  // Auto-save every capture
-                    directory = Directory.PICTURES
-                )
-            )
-        )
+        stateHolder.attachPlugin(imageSaverPlugin)
     }
 )
 ```

--- a/docs/guides/video-recording.md
+++ b/docs/guides/video-recording.md
@@ -2,20 +2,20 @@
 
 # Video Recording
 
-Record high-quality videos with CameraK’s VideoRecorderPlugin. This guide matches the actual usage patterns from the sample app.
+Record high-quality videos with Kamera’s VideoRecorderPlugin. This guide matches the actual usage patterns from the sample app.
 
 ---
 
 ## Overview
 
-CameraK’s video recording is powered by the `VideoRecorderPlugin`, which provides a simple API for starting, stopping, and monitoring video capture. It supports audio, duration limits, and quality selection.
+Kamera’s video recording is powered by the `VideoRecorderPlugin`, which provides a simple API for starting, stopping, and monitoring video capture. It supports audio, duration limits, and quality selection.
 
 ---
 
 
 ## 1. Prerequisites & Permissions
 
-- CameraK and VideoRecorderPlugin dependencies added to your project
+- Kamera and VideoRecorderPlugin dependencies added to your project
 - Camera and storage permissions granted (Android/iOS)
 
 ### Android: Update `AndroidManifest.xml`
@@ -49,7 +49,7 @@ Add the plugin dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:0.3")
+    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:0.4")
 }
 ```
 
@@ -184,7 +184,7 @@ Row(
 
 ## 9. See Also
 
-- [Sample App Usage](https://github.com/Kashif-E/CameraK/blob/main/Sample/src/commonMain/kotlin/org/company/app/App.kt)
+- [Sample App Usage](https://github.com/Kashif-E/Kamera/blob/main/Sample/src/commonMain/kotlin/org/company/app/App.kt)
 - [Plugins Guide](plugins.md)
 - [CameraKScreen API](../api/camera-k-screen.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# CameraK Documentation
+# Kamera Documentation
 
 **Modern camera SDK for Kotlin Multiplatform** -- Android, iOS, and Desktop with a unified API.
 
@@ -6,7 +6,7 @@
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.3")
+    implementation("io.github.kashif-mehmood-km:camerak:0.4")
 }
 ```
 
@@ -48,7 +48,7 @@ fun CameraScreen() {
 
 Start with installation and configuration:
 
-- [Installation](getting-started/installation.md) -- Add CameraK to your project
+- [Installation](getting-started/installation.md) -- Add Kamera to your project
 - [Quick Start](getting-started/quick-start.md) -- Build your first camera app in 5 minutes
 - [Configuration](getting-started/configuration.md) -- Customize camera behavior
 - [Android Example](examples/android.md) -- Android-specific setup
@@ -57,7 +57,7 @@ Start with installation and configuration:
 
 ### State Management
 
-CameraK uses reactive state management via `CameraKStateHolder`:
+Kamera uses reactive state management via `CameraKStateHolder`:
 
 ```kotlin
 sealed class CameraKState {
@@ -87,13 +87,16 @@ expect class CameraController {
 Extend camera functionality modularly:
 
 ```kotlin
+// Create plugins in composable scope, then attach the instances inside setupPlugins.
+val qrScannerPlugin = rememberQRScannerPlugin()
+val ocrPlugin = rememberOcrPlugin()
 val cameraState by rememberCameraKState(
     config = CameraConfiguration(
         cameraLens = CameraLens.BACK,
     ),
     setupPlugins = { stateHolder ->
-        stateHolder.attachPlugin(rememberQRScannerPlugin())
-        stateHolder.attachPlugin(rememberOcrPlugin())
+        stateHolder.attachPlugin(qrScannerPlugin)
+        stateHolder.attachPlugin(ocrPlugin)
     },
 )
 ```
@@ -125,13 +128,13 @@ val cameraState by rememberCameraKState(
 |----------|-----------------|---------|
 | Android  | API 21 (5.0)    | CameraX |
 | iOS      | 13.0            | AVFoundation |
-| Desktop  | JDK 11+         | JavaCV |
+| Desktop  | JDK 17+         | JavaCV |
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/Kashif-E/CameraK/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/Kashif-E/CameraK/discussions)
-- **Examples**: [Sample Projects](https://github.com/Kashif-E/CameraK/tree/main/Sample)
+- **Issues**: [GitHub Issues](https://github.com/Kashif-E/Kamera/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/Kashif-E/Kamera/discussions)
+- **Examples**: [Sample Projects](https://github.com/Kashif-E/Kamera/tree/main/Sample)
 
 ## License
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,6 +1,6 @@
 # License
 
-CameraK is licensed under the Apache License 2.0.
+Kamera is licensed under the Apache License 2.0.
 
 ```
 Copyright 2024 Kashif Mehmood
@@ -21,11 +21,11 @@ limitations under the License.
 ## What This Means
 
 ### You CAN:
-- ✅ Use CameraK in commercial projects
+- ✅ Use Kamera in commercial projects
 - ✅ Modify the source code
 - ✅ Distribute modified versions
-- ✅ Include CameraK in proprietary software
-- ✅ Use CameraK for private projects
+- ✅ Include Kamera in proprietary software
+- ✅ Use Kamera for private projects
 
 ### You MUST:
 - 📄 Include a copy of the Apache 2.0 license
@@ -34,12 +34,12 @@ limitations under the License.
 
 ### You CANNOT:
 - ❌ Hold the author liable for damages
-- ❌ Use CameraK trademarks without permission
+- ❌ Use Kamera trademarks without permission
 - ❌ Claim you wrote the original code
 
 ## Third-Party Licenses
 
-CameraK uses the following open-source libraries:
+Kamera uses the following open-source libraries:
 
 ### Android
 - **CameraX** — Apache 2.0
@@ -60,4 +60,4 @@ https://www.apache.org/licenses/LICENSE-2.0
 
 For licensing questions, contact:
 - GitHub: [@Kashif-E](https://github.com/Kashif-E)
-- Issues: [github.com/Kashif-E/CameraK/issues](https://github.com/Kashif-E/CameraK/issues)
+- Issues: [github.com/Kashif-E/Kamera/issues](https://github.com/Kashif-E/Kamera/issues)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Common issues and solutions for CameraK.
+Common issues and solutions for Kamera.
 
 ## Installation Issues
 
@@ -238,7 +238,7 @@ controller.setZoom(savedZoom.coerceIn(1f, controller.getMaxZoom()))
 **Solution:**
 1. Limit burst captures to 3-5 photos
 2. Use lower resolution
-3. Use `takePictureToFile()` instead of `takePicture()`
+3. Use `takePictureToFile()` — it writes straight to disk instead of buffering the image in memory
 
 ```kotlin
 val cameraState by rememberCameraKState(
@@ -284,10 +284,12 @@ val cameraState by rememberCameraKState(
 **Solution:** Add plugins during initialization using `setupPlugins`:
 
 ```kotlin
+val qrScannerPlugin = rememberQRScannerPlugin()
+val ocrPlugin = rememberOcrPlugin()
 val cameraState by rememberCameraKState(
     setupPlugins = { stateHolder ->
-        stateHolder.attachPlugin(rememberQRScannerPlugin())
-        stateHolder.attachPlugin(rememberOcrPlugin())
+        stateHolder.attachPlugin(qrScannerPlugin)
+        stateHolder.attachPlugin(ocrPlugin)
     },
 )
 ```
@@ -323,7 +325,7 @@ if (lens == null) {
 
 **Issue:** "Camera preview upside down"
 
-**Solution:** Device orientation handling. CameraK handles this automatically - report if issue persists.
+**Solution:** Device orientation handling. Kamera handles this automatically - report if issue persists.
 
 **Issue:** "Camera types not available (TELEPHOTO, ULTRA_WIDE)"
 
@@ -386,15 +388,15 @@ pod install
 
 If you're still stuck:
 
-1. **Check Examples**: [Sample Projects](https://github.com/Kashif-E/CameraK/tree/main/Sample)
-2. **Search Issues**: [GitHub Issues](https://github.com/Kashif-E/CameraK/issues)
-3. **Ask Questions**: [GitHub Discussions](https://github.com/Kashif-E/CameraK/discussions)
-4. **Report Bugs**: [New Issue](https://github.com/Kashif-E/CameraK/issues/new)
+1. **Check Examples**: [Sample Projects](https://github.com/Kashif-E/Kamera/tree/main/Sample)
+2. **Search Issues**: [GitHub Issues](https://github.com/Kashif-E/Kamera/issues)
+3. **Ask Questions**: [GitHub Discussions](https://github.com/Kashif-E/Kamera/discussions)
+4. **Report Bugs**: [New Issue](https://github.com/Kashif-E/Kamera/issues/new)
 
 ### When Reporting Issues
 
 Include:
-- CameraK version
+- Kamera version
 - Platform (Android/iOS/Desktop)
 - Device/emulator details
 - Minimal reproducible code
@@ -403,7 +405,7 @@ Include:
 
 **Good issue:**
 ```
-CameraK 0.3
+Kamera 0.3
 Android 13 (Pixel 6)
 
 Preview shows black screen when using:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -405,7 +405,7 @@ Include:
 
 **Good issue:**
 ```
-Kamera 0.3
+Kamera 0.4
 Android 13 (Pixel 6)
 
 Preview shows black screen when using:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/kashif-e/Kamera
       name: GitHub
-  version: 0.3
+  version: 0.4
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
-site_name: CameraK
+site_name: Kamera
 site_description: Kotlin Multiplatform Camera SDK
 site_author: Kashif-E
-site_url: https://kashif-e.github.io/CameraK/
-repo_url: https://github.com/kashif-e/CameraK
-repo_name: kashif-e/CameraK
+site_url: https://kashif-e.github.io/Kamera/
+repo_url: https://github.com/kashif-e/Kamera
+repo_name: kashif-e/Kamera
 edit_uri: edit/main/docs/
 
 theme:
@@ -83,11 +83,11 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/kashif-e/CameraK
+      link: https://github.com/kashif-e/Kamera
       name: GitHub
   version: 0.3
 
 extra_css:
   - stylesheets/extra.css
 
-copyright: Copyright &copy; 2024 CameraK
+copyright: Copyright &copy; 2024 Kamera


### PR DESCRIPTION
Renames the product name **CameraK → Kamera** across README, docs, and mkdocs, and fixes documentation that referenced nonexistent or removed APIs (found by a page-by-page audit against the source).

Display-rename only — `CameraK*` class names, the `com.kashif.cameraK` package, and the `camerak` Maven artifact id are unchanged.

## Broken examples fixed (would not compile)
- **README** — analyzer snippet used a nonexistent `CameraKEvent.LatestFrame` and had malformed Kotlin; OCR example called a nonexistent `ocrPlugin.recognizeText()`. Rewrote both to the real `getAnalyzerFlow()` / `ocrFlow` APIs.
- **plugins.md, index.md, troubleshooting.md, api/state-holder.md, api/camera-k-screen.md** — examples called `@Composable` `remember*Plugin()` *inside* the `setupPlugins` lambda, or used no-arg `QRScannerPlugin()` / `OcrPlugin()` constructors (they require a `CoroutineScope`). Rewrote all to create-then-attach. `rememberImageSaverPlugin` now passes its required `config`.
- **api/camera-k-screen.md** — `CameraKScreen` signature was missing `deviceOrientation` and `overlay`; corrected and documented both.

## Content updates
- `CHANGELOG.md` `[Unreleased]` rewritten with the actually-merged work (#129–#134) — the old section still advertised the removed API toggle.
- Documented `mirrorFrontCamera` and `CameraKLogger`; removed the dead `returnFilePath` references.
- `api/state-holder.md` — `CameraUIState` / `CameraKEvent` blocks updated to match source.
- `camera-capture.md` — clarified `takePictureToFile()` never returns `Success(byteArray)`.
- Bumped all dependency coordinates `0.2.0`/`0.3` → **0.4**; fixed `analzer_plugin` typo; repo URLs → `Kashif-E/Kamera`; JDK 11 → 17.

Markdown-only — no build impact. A final sweep confirms no removed/nonexistent APIs remain in any doc.