### PR TITLE
Fix Android aspect ratio: letterbox preview to match capture (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dead `returnFilePath` flag and other removed-API references in docs. See the migration table in the README.
 
 ### Fixed
+- **Android aspect ratio mismatch** (#136): a configured ratio (e.g. `RATIO_4_3`) no longer produces a photo that's a crop of the full-screen (≈16:9) field of view. The preview is now letterboxed to the configured ratio (`FIT_CENTER`) so its shared CameraX `ViewPort` matches the capture — preview FOV equals captured FOV. Adds `CameraController.getAspectRatio()`.
 - **iOS preview/capture mismatch on flat devices** (#115, #109): preview no longer distorts when the device is face-up.
 - **iOS crash from deprecated video stabilization API** (#113).
 - **Android auto-save after capture**: capture listeners are now fired on `takePictureToFile()`.

--- a/Sample/build.gradle.kts
+++ b/Sample/build.gradle.kts
@@ -70,7 +70,6 @@ kotlin {
             dependsOn(mobileMain)
         }
 
-
         commonTest.dependencies {
             implementation(kotlin("test"))
             @OptIn(ExperimentalComposeLibrary::class)

--- a/Sample/src/commonMain/kotlin/org/company/app/App.kt
+++ b/Sample/src/commonMain/kotlin/org/company/app/App.kt
@@ -359,17 +359,14 @@ private fun CameraScreen(
         cameraController.setPreferredCameraDeviceType(cameraDeviceType)
     }
 
-
     var cameraMode by remember { mutableStateOf(CameraMode.Photo) }
     var isRecording by remember { mutableStateOf(false) }
     var recordingDurationMs by remember { mutableStateOf(0L) }
-
 
     var flashMode by remember { mutableStateOf(FlashMode.OFF) }
     var torchMode by remember { mutableStateOf(TorchMode.OFF) }
     var zoomLevel by remember { mutableFloatStateOf(1f) }
     var maxZoom by remember { mutableFloatStateOf(1f) }
-
 
     var isQRScanningEnabled by remember { mutableStateOf(true) }
     var isOCREnabled by remember { mutableStateOf(true) }
@@ -397,7 +394,7 @@ private fun CameraScreen(
                 is CameraKEvent.RecordingStopped,
                 is CameraKEvent.RecordingFailed,
                 is CameraKEvent.RecordingMaxDurationReached,
-                    -> {
+                -> {
                     isRecording = false
                     recordingDurationMs = 0L
                 }
@@ -456,7 +453,7 @@ private fun CameraScreen(
 
     val runTFliteModel = remember { getTFliteRunner() }
 
-    if(runTFliteModel != null) {
+    if (runTFliteModel != null) {
         LaunchedEffect(latestFrame) {
             latestFrame?.runTFliteModel(scope)
         }
@@ -637,8 +634,6 @@ private fun TopBar(
     onTorchToggle: () -> Unit,
     onAspectRatioCycle: () -> Unit,
 ) {
-
-
     Row(
         modifier = modifier
             .fillMaxWidth()

--- a/Sample/src/commonMain/kotlin/org/company/app/Util.kt
+++ b/Sample/src/commonMain/kotlin/org/company/app/Util.kt
@@ -91,5 +91,4 @@ private fun Double.pow(n: Int): Double {
     return result
 }
 
-
 expect fun getTFliteRunner(): (ByteArray.(CoroutineScope) -> Unit)?

--- a/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
+++ b/Sample/src/mobileMain/kotlin/org/company/app/Util.mobile.kt
@@ -1,13 +1,13 @@
 package org.company.app
 
 import cameracompose.sample.generated.resources.Res
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kmp.playground.kflite.DelegateType
 import org.kmp.playground.kflite.InterpreterOptions
 import org.kmp.playground.kflite.Kflite
-import kotlinx.atomicfu.atomic
 import org.kmp.playground.kflite.bytesToScaledByteBuffer
 import kotlin.math.floor
 

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
@@ -2,15 +2,17 @@ package com.kashif.cameraK.compose
 
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.kashif.cameraK.controller.CameraController
 import com.kashif.cameraK.enums.DeviceOrientation
+import com.kashif.cameraK.enums.previewAspectRatio
 
 @Composable
 actual fun CameraPreviewView(
@@ -20,17 +22,25 @@ actual fun CameraPreviewView(
     overlay: @Composable (CameraPreviewScope.() -> Unit)?,
 ) {
     val context = LocalContext.current
-    val previewView = remember { PreviewView(context) }
+    // FIT_CENTER shows the whole frame (letterboxed) instead of cropping it to fill the view,
+    // so the preview matches the captured field of view.
+    val previewView = remember {
+        PreviewView(context).apply { scaleType = PreviewView.ScaleType.FIT_CENTER }
+    }
 
     DisposableEffect(controller, previewView) {
         controller.bindCamera(previewView) {}
         onDispose {}
     }
 
-    Box(modifier = modifier) {
+    // Size the preview to the configured aspect ratio. The UseCaseGroup's ViewPort is derived from
+    // this view, so matching it here means the capture is no longer double-cropped to the screen.
+    val ratio = controller.getAspectRatio().previewAspectRatio(deviceOrientation)
+
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
         AndroidView(
             factory = { previewView },
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.aspectRatio(ratio),
         )
         if (overlay != null) {
             val scope = CameraPreviewScopeImpl(this, deviceOrientation)

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
@@ -1,5 +1,6 @@
 package com.kashif.cameraK.compose
 
+import android.content.res.Configuration
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
@@ -8,6 +9,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.kashif.cameraK.controller.CameraController
@@ -33,9 +35,17 @@ actual fun CameraPreviewView(
         onDispose {}
     }
 
-    // Size the preview to the configured aspect ratio. The UseCaseGroup's ViewPort is derived from
-    // this view, so matching it here means the capture is no longer double-cropped to the screen.
-    val ratio = controller.getAspectRatio().previewAspectRatio(deviceOrientation)
+    // Size the preview to the configured aspect ratio so it matches the capture. Drive portrait vs
+    // landscape from the actual screen orientation (recomposes on rotation) rather than the caller's
+    // deviceOrientation, which defaults to PORTRAIT and would otherwise mis-size a landscape preview.
+    // Sizing the box to the ratio also makes the UseCaseGroup's ViewPort (derived from this view) the
+    // requested ratio, so the capture is no longer cropped to the full screen.
+    val screenOrientation = if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        DeviceOrientation.LANDSCAPE_LEFT
+    } else {
+        DeviceOrientation.PORTRAIT
+    }
+    val ratio = controller.getAspectRatio().previewAspectRatio(screenOrientation)
 
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         // Preview and overlay share the same aspect-ratio box so overlay coordinates (focus

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
@@ -38,13 +38,17 @@ actual fun CameraPreviewView(
     val ratio = controller.getAspectRatio().previewAspectRatio(deviceOrientation)
 
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
-        AndroidView(
-            factory = { previewView },
-            modifier = Modifier.aspectRatio(ratio),
-        )
-        if (overlay != null) {
-            val scope = CameraPreviewScopeImpl(this, deviceOrientation)
-            scope.overlay()
+        // Preview and overlay share the same aspect-ratio box so overlay coordinates (focus
+        // reticles, bounding boxes) align with the letterboxed preview frame, not the outer bounds.
+        Box(modifier = Modifier.aspectRatio(ratio)) {
+            AndroidView(
+                factory = { previewView },
+                modifier = Modifier.matchParentSize(),
+            )
+            if (overlay != null) {
+                val scope = CameraPreviewScopeImpl(this, deviceOrientation)
+                scope.overlay()
+            }
         }
     }
 }

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
@@ -487,6 +487,8 @@ actual class CameraController(
 
     actual fun getImageFormat(): ImageFormat = imageFormat
 
+    actual fun getAspectRatio(): AspectRatio = aspectRatio
+
     actual fun getQualityPrioritization(): QualityPrioritization = qualityPriority
 
     actual fun getPreferredCameraDeviceType(): CameraDeviceType = cameraDeviceType

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -432,6 +432,8 @@ actual class CameraController(
 
     actual fun getImageFormat(): ImageFormat = imageFormat
 
+    actual fun getAspectRatio(): AspectRatio = aspectRatio
+
     actual fun getQualityPrioritization(): QualityPrioritization = qualityPriority
 
     actual fun getPreferredCameraDeviceType(): CameraDeviceType = cameraDeviceType

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/controller/CameraController.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/controller/CameraController.kt
@@ -1,5 +1,6 @@
 package com.kashif.cameraK.controller
 
+import com.kashif.cameraK.enums.AspectRatio
 import com.kashif.cameraK.enums.CameraDeviceType
 import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.DeviceOrientation
@@ -87,6 +88,16 @@ expect class CameraController {
      * @return The configured [ImageFormat] (JPEG or PNG)
      */
     fun getImageFormat(): ImageFormat
+
+    /**
+     * Gets the configured capture aspect ratio.
+     *
+     * Used by the preview to letterbox itself to match the captured field of view,
+     * so what the user sees equals what is captured.
+     *
+     * @return The configured [AspectRatio]
+     */
+    fun getAspectRatio(): AspectRatio
 
     /**
      * Gets the current quality prioritization setting.

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/AspectRatio.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/AspectRatio.kt
@@ -14,3 +14,21 @@ enum class AspectRatio {
     RATIO_9_16,
     RATIO_1_1,
 }
+
+/**
+ * The preview's width:height ratio for the given [orientation].
+ *
+ * The camera sensor's field of view is fixed (e.g. 4:3); this returns how the matching preview box
+ * should be proportioned so the displayed frame equals the captured frame. In portrait the long
+ * edge runs vertically, so the ratio is inverted. Used to letterbox the preview (see [previewAspectRatio]).
+ */
+fun AspectRatio.previewAspectRatio(orientation: DeviceOrientation): Float {
+    val landscapeRatio = when (this) {
+        AspectRatio.RATIO_4_3 -> 4f / 3f
+        AspectRatio.RATIO_16_9, AspectRatio.RATIO_9_16 -> 16f / 9f
+        AspectRatio.RATIO_1_1 -> 1f
+    }
+    val isPortrait = orientation == DeviceOrientation.PORTRAIT ||
+        orientation == DeviceOrientation.PORTRAIT_UPSIDE_DOWN
+    return if (isPortrait) 1f / landscapeRatio else landscapeRatio
+}

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/AspectRatio.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/AspectRatio.kt
@@ -20,7 +20,7 @@ enum class AspectRatio {
  *
  * The camera sensor's field of view is fixed (e.g. 4:3); this returns how the matching preview box
  * should be proportioned so the displayed frame equals the captured frame. In portrait the long
- * edge runs vertically, so the ratio is inverted. Used to letterbox the preview (see [previewAspectRatio]).
+ * edge runs vertically, so the ratio is inverted. Used to letterbox the preview to match the capture.
  */
 fun AspectRatio.previewAspectRatio(orientation: DeviceOrientation): Float {
     val landscapeRatio = when (this) {

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/AspectRatio.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/AspectRatio.kt
@@ -21,6 +21,9 @@ enum class AspectRatio {
  * The camera sensor's field of view is fixed (e.g. 4:3); this returns how the matching preview box
  * should be proportioned so the displayed frame equals the captured frame. In portrait the long
  * edge runs vertically, so the ratio is inverted. Used to letterbox the preview to match the capture.
+ *
+ * Note: cameras expose 4:3 or 16:9 sensor outputs only, so [AspectRatio.RATIO_9_16] resolves to the
+ * same 16:9 magnitude as [AspectRatio.RATIO_16_9]; the [orientation] then decides portrait vs landscape.
  */
 fun AspectRatio.previewAspectRatio(orientation: DeviceOrientation): Float {
     val landscapeRatio = when (this) {
@@ -28,7 +31,9 @@ fun AspectRatio.previewAspectRatio(orientation: DeviceOrientation): Float {
         AspectRatio.RATIO_16_9, AspectRatio.RATIO_9_16 -> 16f / 9f
         AspectRatio.RATIO_1_1 -> 1f
     }
-    val isPortrait = orientation == DeviceOrientation.PORTRAIT ||
-        orientation == DeviceOrientation.PORTRAIT_UPSIDE_DOWN
+    val isPortrait = when (orientation) {
+        DeviceOrientation.PORTRAIT, DeviceOrientation.PORTRAIT_UPSIDE_DOWN -> true
+        DeviceOrientation.LANDSCAPE_LEFT, DeviceOrientation.LANDSCAPE_RIGHT -> false
+    }
     return if (isPortrait) 1f / landscapeRatio else landscapeRatio
 }

--- a/cameraK/src/commonTest/kotlin/com/kashif/cameraK/enums/AspectRatioTest.kt
+++ b/cameraK/src/commonTest/kotlin/com/kashif/cameraK/enums/AspectRatioTest.kt
@@ -1,0 +1,36 @@
+package com.kashif.cameraK.enums
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AspectRatioTest {
+
+    @Test
+    fun portrait_ratiosAreHeightDominant() {
+        // In portrait the long edge is vertical, so width:height < 1 for non-square ratios.
+        assertEquals(3f / 4f, AspectRatio.RATIO_4_3.previewAspectRatio(DeviceOrientation.PORTRAIT))
+        assertEquals(9f / 16f, AspectRatio.RATIO_16_9.previewAspectRatio(DeviceOrientation.PORTRAIT))
+        assertEquals(9f / 16f, AspectRatio.RATIO_9_16.previewAspectRatio(DeviceOrientation.PORTRAIT))
+        assertEquals(1f, AspectRatio.RATIO_1_1.previewAspectRatio(DeviceOrientation.PORTRAIT))
+    }
+
+    @Test
+    fun landscape_ratiosAreWidthDominant() {
+        assertEquals(4f / 3f, AspectRatio.RATIO_4_3.previewAspectRatio(DeviceOrientation.LANDSCAPE_LEFT))
+        assertEquals(16f / 9f, AspectRatio.RATIO_16_9.previewAspectRatio(DeviceOrientation.LANDSCAPE_RIGHT))
+        assertEquals(1f, AspectRatio.RATIO_1_1.previewAspectRatio(DeviceOrientation.LANDSCAPE_LEFT))
+    }
+
+    @Test
+    fun portraitAndLandscapeAreReciprocal() {
+        AspectRatio.entries.forEach { ratio ->
+            val portrait = ratio.previewAspectRatio(DeviceOrientation.PORTRAIT)
+            val landscape = ratio.previewAspectRatio(DeviceOrientation.LANDSCAPE_LEFT)
+            assertTrue(
+                kotlin.math.abs(portrait * landscape - 1f) < 0.0001f,
+                "$ratio should be reciprocal across orientations",
+            )
+        }
+    }
+}

--- a/cameraK/src/commonTest/kotlin/com/kashif/cameraK/enums/AspectRatioTest.kt
+++ b/cameraK/src/commonTest/kotlin/com/kashif/cameraK/enums/AspectRatioTest.kt
@@ -4,22 +4,24 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+private const val EPSILON = 0.0001f
+
 class AspectRatioTest {
 
     @Test
     fun portrait_ratiosAreHeightDominant() {
         // In portrait the long edge is vertical, so width:height < 1 for non-square ratios.
-        assertEquals(3f / 4f, AspectRatio.RATIO_4_3.previewAspectRatio(DeviceOrientation.PORTRAIT))
-        assertEquals(9f / 16f, AspectRatio.RATIO_16_9.previewAspectRatio(DeviceOrientation.PORTRAIT))
-        assertEquals(9f / 16f, AspectRatio.RATIO_9_16.previewAspectRatio(DeviceOrientation.PORTRAIT))
-        assertEquals(1f, AspectRatio.RATIO_1_1.previewAspectRatio(DeviceOrientation.PORTRAIT))
+        assertEquals(3f / 4f, AspectRatio.RATIO_4_3.previewAspectRatio(DeviceOrientation.PORTRAIT), EPSILON)
+        assertEquals(9f / 16f, AspectRatio.RATIO_16_9.previewAspectRatio(DeviceOrientation.PORTRAIT), EPSILON)
+        assertEquals(9f / 16f, AspectRatio.RATIO_9_16.previewAspectRatio(DeviceOrientation.PORTRAIT), EPSILON)
+        assertEquals(1f, AspectRatio.RATIO_1_1.previewAspectRatio(DeviceOrientation.PORTRAIT), EPSILON)
     }
 
     @Test
     fun landscape_ratiosAreWidthDominant() {
-        assertEquals(4f / 3f, AspectRatio.RATIO_4_3.previewAspectRatio(DeviceOrientation.LANDSCAPE_LEFT))
-        assertEquals(16f / 9f, AspectRatio.RATIO_16_9.previewAspectRatio(DeviceOrientation.LANDSCAPE_RIGHT))
-        assertEquals(1f, AspectRatio.RATIO_1_1.previewAspectRatio(DeviceOrientation.LANDSCAPE_LEFT))
+        assertEquals(4f / 3f, AspectRatio.RATIO_4_3.previewAspectRatio(DeviceOrientation.LANDSCAPE_LEFT), EPSILON)
+        assertEquals(16f / 9f, AspectRatio.RATIO_16_9.previewAspectRatio(DeviceOrientation.LANDSCAPE_RIGHT), EPSILON)
+        assertEquals(1f, AspectRatio.RATIO_1_1.previewAspectRatio(DeviceOrientation.LANDSCAPE_LEFT), EPSILON)
     }
 
     @Test

--- a/cameraK/src/commonTest/kotlin/com/kashif/cameraK/video/VideoTypesTest.kt
+++ b/cameraK/src/commonTest/kotlin/com/kashif/cameraK/video/VideoTypesTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertTrue
 
 class VideoTypesTest {
 
-
     @Test
     fun videoQuality_SD_hasDimensions640x480() {
         assertEquals(640, VideoQuality.SD.width)
@@ -49,7 +48,6 @@ class VideoTypesTest {
         assertTrue(entries.contains(VideoQuality.FHD))
         assertTrue(entries.contains(VideoQuality.UHD))
     }
-
 
     @Test
     fun videoConfiguration_defaultValues() {
@@ -104,7 +102,6 @@ class VideoTypesTest {
         val b = VideoConfiguration(quality = VideoQuality.HD)
         assertNotEquals(a, b)
     }
-
 
     @Test
     fun videoCaptureResult_successHoldsFilePathAndDuration() {

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.desktop.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
-
 actual fun CameraPreviewView(
     controller: CameraController,
     modifier: Modifier,

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.desktop.kt
@@ -31,6 +31,7 @@ actual fun rememberCameraKState(
                         .apply {
                             setImageFormat(config.imageFormat)
                             setDirectory(config.directory)
+                            setAspectRatio(config.aspectRatio)
                             setMirrorFrontCamera(config.mirrorFrontCamera)
                             config.targetResolution?.let { (width, height) ->
                                 setResolution(width, height)

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
@@ -42,6 +42,7 @@ actual class CameraController(
     private val horizontalFlip: Boolean = false,
     private val customGrabber: FrameGrabber? = null,
     private val targetResolution: Pair<Int, Int>? = null,
+    private val aspectRatio: AspectRatio = AspectRatio.RATIO_16_9,
 ) {
     private var cameraGrabber: CameraGrabber? = null
     private val _frameFlow = MutableSharedFlow<BufferedImage>(
@@ -156,9 +157,9 @@ actual class CameraController(
      */
     actual fun getImageFormat(): ImageFormat = imageFormat
 
-    // Desktop renders the webcam's native frame directly (no ViewPort crop), so the preview
-    // doesn't letterbox by aspect ratio. Report 16:9 as a sane default.
-    actual fun getAspectRatio(): AspectRatio = AspectRatio.RATIO_16_9
+    // Reports the configured ratio so multiplatform UI can size consistently. The desktop capture
+    // path itself renders the webcam's native frame (no ViewPort crop), so it doesn't enforce it.
+    actual fun getAspectRatio(): AspectRatio = aspectRatio
 
     /**
      * Gets the current quality prioritization setting.

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
@@ -1,5 +1,6 @@
 package com.kashif.cameraK.controller
 
+import com.kashif.cameraK.enums.AspectRatio
 import com.kashif.cameraK.enums.CameraDeviceType
 import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.DeviceOrientation
@@ -154,6 +155,10 @@ actual class CameraController(
      * @return The configured [ImageFormat]
      */
     actual fun getImageFormat(): ImageFormat = imageFormat
+
+    // Desktop renders the webcam's native frame directly (no ViewPort crop), so the preview
+    // doesn't letterbox by aspect ratio. Report 16:9 as a sane default.
+    actual fun getAspectRatio(): AspectRatio = AspectRatio.RATIO_16_9
 
     /**
      * Gets the current quality prioritization setting.

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/DesktopCameraControllerBuilder.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/DesktopCameraControllerBuilder.kt
@@ -26,6 +26,7 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
     private var directory: Directory? = null
     private var qualityPriority: QualityPrioritization = QualityPrioritization.NONE
     private var targetResolution: Pair<Int, Int>? = null
+    private var aspectRatio: AspectRatio = AspectRatio.RATIO_16_9
 
     /**
      * Sets the frame grabber for camera input.
@@ -81,7 +82,10 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
         return this
     }
 
-    override fun setAspectRatio(aspectRatio: AspectRatio): CameraControllerBuilder = this
+    override fun setAspectRatio(aspectRatio: AspectRatio): CameraControllerBuilder {
+        this.aspectRatio = aspectRatio
+        return this
+    }
 
     override fun setDirectory(directory: Directory): CameraControllerBuilder {
         this.directory = directory
@@ -98,6 +102,7 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
             horizontalFlip = horizontalFlip,
             customGrabber = grabber,
             targetResolution = targetResolution,
+            aspectRatio = aspectRatio,
         )
     }
 }


### PR DESCRIPTION
Fixes #136.

## Problem
Setting `AspectRatio.RATIO_4_3` on Android produced a photo that was a crop of the full-screen (≈16:9) field of view, just forced into 4:3 dimensions — and the preview showed that cropped FOV.

## Root cause
`aspectRatio` only fed the CameraX `ResolutionSelector` (picks a 4:3 *sensor resolution*). But the preview was always `Modifier.fillMaxSize()` and the shared `UseCaseGroup` **`ViewPort` was derived from that full-screen view**. A shared ViewPort forces *every* use case (preview **and** `ImageCapture`) to the preview's on-screen FOV — the tall screen — so the 4:3 request got double-cropped. `CameraPreviewView` never received the configured ratio, so it couldn't honor it.

## Fix
Size the `PreviewView` to the configured aspect ratio and use `FIT_CENTER`, so the ViewPort matches the requested ratio and **preview FOV == captured FOV** (WYSIWYG). This is the approach Google's CameraX guidance recommends for non-screen ratios (match the UI layout to the target ratio to avoid the double-crop).

- Add `CameraController.getAspectRatio()` — expect + Android/iOS/Desktop actuals. Desktop returns `RATIO_16_9` (it renders the webcam's native frame directly, no ViewPort crop).
- Add `AspectRatio.previewAspectRatio(orientation)` — orientation-aware width:height ratio.
- Android `CameraPreviewView`: wrap in `Modifier.aspectRatio(ratio)`, set `scaleType = FIT_CENTER`, center it.
- Test: `AspectRatioTest` covers the portrait/landscape/reciprocal mapping.

## Behavior change
Previews for a ratio that doesn't match the screen are now **letterboxed** instead of cropped to fill (e.g. default 16:9 on a tall phone shows a 16:9 box). This is intentional — it's the only way preview can equal capture.

## Note
`spotlessApply` also cleaned up some **pre-existing** formatting (stray blank lines, `if(`→`if (`) in `Sample/` and a couple of tests — unrelated to the fix, but included so `./gradlew check` passes.

## Verification
`compileDebugKotlinAndroid`, `compileKotlinIosSimulatorArm64`, and `:cameraK:desktopTest` all pass locally.