### PR TITLE
Fix iOS underexposed/black photos (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dead `returnFilePath` flag and other removed-API references in docs. See the migration table in the README.
 
 ### Fixed
+- **iOS underexposed/black photos** (#138): `MemoryManager` compared `physicalMemory` to itself, so it reported 100% usage and `isUnderMemoryPressure()` latched on permanently. That made every capture downshift the session preset (`adjustSessionQuality`) synchronously right before `capturePhotoWithSettings`, capturing the still mid-reconfiguration before auto-exposure re-converged. Most visible on front-camera selfies; masked when a plugin (OCR/QR/Analyzer) kept an `AVCaptureVideoDataOutput` streaming. Memory pressure is now driven by the system memory-warning notification, and the capture no longer reconfigures the preset at shot time.
 - **Android aspect ratio mismatch** (#136): a configured ratio (e.g. `RATIO_4_3`) no longer produces a photo that's a crop of the full-screen (≈16:9) field of view. The preview is now letterboxed to the configured ratio (`FIT_CENTER`) so its shared CameraX `ViewPort` matches the capture — preview FOV equals captured FOV. Adds `CameraController.getAspectRatio()`.
 - **iOS preview/capture mismatch on flat devices** (#115, #109): preview no longer distorts when the device is face-up.
 - **iOS crash from deprecated video stabilization API** (#113).

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
@@ -5,7 +5,6 @@ import com.kashif.cameraK.enums.CameraDeviceType
 import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.utils.CameraKLogger
-import com.kashif.cameraK.utils.MemoryManager
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.AVFoundation.*
 import platform.Foundation.NSData
@@ -428,26 +427,6 @@ class CustomCameraController(
     fun getMaxZoom(): Float = currentCamera?.activeFormat?.videoMaxZoomFactor?.toFloat() ?: 1.0f
 
     /**
-     * Sets the session preset quality based on memory conditions
-     * This allows for dynamic adjustment of capture quality
-     */
-    private fun adjustSessionQuality() {
-        captureSession?.beginConfiguration()
-
-        val memoryUsage = MemoryManager.getMemoryUsagePercentage()
-        val underPressure = MemoryManager.isUnderMemoryPressure()
-
-        val newPreset = when {
-            underPressure -> AVCaptureSessionPresetMedium
-            memoryUsage > 70 -> AVCaptureSessionPresetHigh
-            else -> AVCaptureSessionPresetPhoto
-        }
-
-        captureSession?.sessionPreset = newPreset
-        captureSession?.commitConfiguration()
-    }
-
-    /**
      * Capture an image. Output quality is governed by the configured [qualityPrioritization].
      */
     fun captureImage() {
@@ -456,9 +435,10 @@ class CustomCameraController(
             return
         }
 
-        if (MemoryManager.isUnderMemoryPressure()) {
-            adjustSessionQuality()
-        }
+        // Do NOT reconfigure the session preset here. Switching the preset synchronously right
+        // before capturePhotoWithSettings disrupts auto-exposure, so the still is captured
+        // mid-reconfiguration and comes out underexposed (#138). The preset is chosen once at
+        // setup; memory pressure is handled by clearing buffer pools, not by downshifting capture.
 
         val settings = AVCapturePhotoSettings.photoSettingsWithFormat(
             mapOf(

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/utils/MemoryManager.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/utils/MemoryManager.kt
@@ -49,15 +49,12 @@ object MemoryManager {
      * This should be called periodically, especially before major memory operations
      */
     fun updateMemoryStatus() {
-        // Pressure is driven by the system memory-warning notification (the reliable iOS signal,
-        // see registerMemoryWarningNotification). We can't cheaply measure this process's footprint
-        // here, and the previous code compared physicalMemory to itself — pinning "usage" at 100%
-        // and latching pressure on forever, which made every capture downshift the session preset
-        // and underexpose the photo (#138). Treat a prior warning as transient: now that buffers
-        // have been freed and we're between operations, clear the flag.
-        if (memoryPressure.value) {
-            memoryPressure.value = false
-        }
+        // No-op: iOS exposes no cheap, reliable per-process memory gauge, so pressure is driven
+        // solely by the system memory-warning notification (see registerMemoryWarningNotification),
+        // which callers can observe via isUnderMemoryPressure(). The previous code compared
+        // physicalMemory to itself — pinning "usage" at 100% and latching pressure on permanently,
+        // which made every capture downshift the session preset and underexpose the photo (#138).
+        // Kept as a hook so existing call sites stay valid.
     }
 
     /**

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/utils/MemoryManager.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/utils/MemoryManager.kt
@@ -4,7 +4,6 @@ import kotlinx.atomicfu.atomic
 import platform.Foundation.NSLock
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
-import platform.Foundation.NSProcessInfo
 import platform.UIKit.UIApplicationDidReceiveMemoryWarningNotification
 
 /**
@@ -12,15 +11,11 @@ import platform.UIKit.UIApplicationDidReceiveMemoryWarningNotification
  * Monitors memory pressure and optimizes memory usage for image capture operations
  */
 object MemoryManager {
-    private const val MEMORY_PRESSURE_THRESHOLD = 0.8
-
     private val smallBufferLock = NSLock()
     private val mediumBufferLock = NSLock()
     private val largeBufferLock = NSLock()
 
     private val memoryPressure = atomic(false)
-
-    private var memoryUsage = atomic(0.0)
 
     private val smallBufferPool = mutableListOf<ByteArray>()
     private val mediumBufferPool = mutableListOf<ByteArray>()
@@ -54,19 +49,14 @@ object MemoryManager {
      * This should be called periodically, especially before major memory operations
      */
     fun updateMemoryStatus() {
-        val usedMemory = getUsedMemory()
-        val totalMemory = getTotalMemory()
-
-        if (totalMemory > 0) {
-            val usage = usedMemory / totalMemory
-            memoryUsage.value = usage
-
-            if (usage > MEMORY_PRESSURE_THRESHOLD && !memoryPressure.value) {
-                memoryPressure.value = true
-                handleHighMemoryPressure()
-            } else if (usage <= MEMORY_PRESSURE_THRESHOLD && memoryPressure.value) {
-                memoryPressure.value = false
-            }
+        // Pressure is driven by the system memory-warning notification (the reliable iOS signal,
+        // see registerMemoryWarningNotification). We can't cheaply measure this process's footprint
+        // here, and the previous code compared physicalMemory to itself — pinning "usage" at 100%
+        // and latching pressure on forever, which made every capture downshift the session preset
+        // and underexpose the photo (#138). Treat a prior warning as transient: now that buffers
+        // have been freed and we're between operations, clear the flag.
+        if (memoryPressure.value) {
+            memoryPressure.value = false
         }
     }
 
@@ -172,29 +162,10 @@ object MemoryManager {
     /**
      * Get optimal image quality based on memory conditions
      */
-    fun getOptimalImageQuality(): Double = when {
-        memoryPressure.value -> 0.6
-        memoryUsage.value > 0.7 -> 0.75
-        else -> 0.95
-    }
+    fun getOptimalImageQuality(): Double = if (memoryPressure.value) 0.6 else 0.95
 
     /**
      * Check if memory is under pressure
      */
     fun isUnderMemoryPressure(): Boolean = memoryPressure.value
-
-    /**
-     * Get memory usage as a percentage
-     */
-    fun getMemoryUsagePercentage(): Double = memoryUsage.value * 100
-
-    /**
-     * Get used memory in bytes - uses physical footprint for accurate measurement
-     */
-    private fun getUsedMemory(): Double = NSProcessInfo.processInfo.physicalMemory.toDouble()
-
-    /**
-     * Get total available memory in bytes
-     */
-    private fun getTotalMemory(): Double = NSProcessInfo.processInfo.physicalMemory.toDouble()
 }


### PR DESCRIPTION
Fixes #138.

## Symptom
On iOS (reported on iPhone 13 / iOS 26), the live preview is correctly exposed but captured photos — especially front-camera selfies — come out underexposed or black. The reporter found that **disabling OCR/QR made it worse and enabling OCR fixed it**, and a plugin-free app (`camerak` only) always reproduces it.

## Root cause
Two layered bugs:

1. **`MemoryManager` always reported memory pressure.** `getUsedMemory()` and `getTotalMemory()` both returned `NSProcessInfo.physicalMemory` (total RAM), so `usage = 100%`, which trips the `0.8` threshold and latches `isUnderMemoryPressure()` **permanently true**.
2. **That made every capture reconfigure the session at shot time.** `captureImage()` ran `adjustSessionQuality()` whenever "under pressure", switching the `AVCaptureSession` preset to `Medium` and `commitConfiguration()` **synchronously right before `capturePhotoWithSettings`**. The still is captured mid-reconfiguration, before auto-exposure re-converges → underexposed/black, while the preview stays correct.

**Why OCR masked it:** the OCR/QR/Analyzer plugins attach an always-on `AVCaptureVideoDataOutput`. Continuous frame delivery keeps the pipeline streaming (and constrains the `Medium` switch), so the post-reconfigure frame is properly exposed. Without a plugin there's nothing masking it.

## Fix
- **`MemoryManager`** — drive pressure from the system memory-warning notification (`UIApplicationDidReceiveMemoryWarningNotification`, already registered) and treat it as transient; drop the bogus `physicalMemory / physicalMemory` ratio and the dead getters. `isUnderMemoryPressure()` is now accurate, which also stops `BurstCaptureManager` from permanently scaling capture quality down.
- **`captureImage()`** — remove the pre-capture `adjustSessionQuality()` preset switch. The preset is selected once at setup; memory pressure is handled by clearing buffer pools, not by downshifting the live capture right before a shot.

Net: 13 insertions, 62 deletions across 2 files.

## Verification
`compileKotlinIosSimulatorArm64`, `compileKotlinIosX64/Arm64`, and `:cameraK:desktopTest` pass locally. I could not reproduce on an iPhone 14 Pro (it doesn't hit the disruptive timing the same way), so final confirmation should come from the reporter on the iPhone 13.