### PR TITLE
Release 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Kamera project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Kamera project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0] - 2026-06-19
 
 ### Added
 - **Opt-in logging (`CameraKLogger`)** (#133): internal logging is now disabled by default and routed through `CameraKLogger`. Set `CameraKLogger.enabled = true` to turn it on, or provide a custom `CameraKLogger.sink` to forward logs to your own logger.

--- a/ImageSaverPlugin/build.gradle.kts
+++ b/ImageSaverPlugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.kashif.image_saver_plugin"
-version = "0.4"
+version = "1.0"
 
 kotlin {
     jvmToolchain(17)
@@ -75,7 +75,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "image_saver_plugin",
-        version = "0.4",
+        version = "1.0",
     )
 
     pom {

--- a/README.MD
+++ b/README.MD
@@ -34,14 +34,14 @@ Add dependencies to your `build.gradle.kts`:
 ```kotlin
 dependencies {
     // Core library
-    implementation("io.github.kashif-mehmood-km:camerak:0.4")
+    implementation("io.github.kashif-mehmood-km:camerak:1.0")
 
     // Optional plugins
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
-    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:0.4")
-    implementation("io.github.kashif-mehmood-km:analyzer_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:analyzer_plugin:1.0")
 }
 ```
 
@@ -51,7 +51,7 @@ Add to your `libs.versions.toml`:
 
 ```toml
 [versions]
-camerak = "0.4"
+camerak = "1.0"
 
 [libraries]
 camerak = { module = "io.github.kashif-mehmood-km:camerak", version.ref = "camerak" }
@@ -994,10 +994,10 @@ LaunchedEffect(ocrPlugin) {
 
 ```gradle
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.4")
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:camerak:1.0")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
 }
 ```
 

--- a/analyzerPlugin/build.gradle.kts
+++ b/analyzerPlugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.kashif.analyzer_plugin"
-version = "0.4"
+version = "1.0"
 
 kotlin {
     jvmToolchain(17)
@@ -83,7 +83,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "analyzer_plugin",
-        version = "0.4",
+        version = "1.0",
     )
 
     pom {

--- a/cameraK/build.gradle.kts
+++ b/cameraK/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.kashif.camera_compose"
-version = "0.4"
+version = "1.0"
 
 kotlin {
     jvmToolchain(17)
@@ -106,7 +106,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "camerak",
-        version = "0.4",
+        version = "1.0",
     )
 
     pom {

--- a/cameraK/build.gradle.kts
+++ b/cameraK/build.gradle.kts
@@ -144,7 +144,7 @@ mavenPublishing {
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
     moduleName.set("CameraK")
-    moduleVersion.set("0.4")
+    moduleVersion.set("1.0")
     outputDirectory.set(file("${layout.buildDirectory}/dokka/html"))
 
     pluginsMapConfiguration.set(

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ Before creating an issue, please:
 ### Good Issue Example
 
 ```markdown
-**Kamera Version:** 0.4
+**Kamera Version:** 1.0
 **Platform:** Android 13 (Pixel 6)
 
 **Description:**

--- a/docs/examples/android.md
+++ b/docs/examples/android.md
@@ -16,7 +16,7 @@ Setup Kamera for Android applications.
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.4")
+    implementation("io.github.kashif-mehmood-km:camerak:1.0")
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 
 ```toml
 [versions]
-camerak = "0.4"
+camerak = "1.0"
 
 [libraries]
 camerak = { module = "io.github.kashif-mehmood-km:camerak", version.ref = "camerak" }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ Add to your `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.kashif-mehmood-km:camerak:0.4")
+            implementation("io.github.kashif-mehmood-km:camerak:1.0")
         }
     }
 }
@@ -33,7 +33,7 @@ Add to `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-camerak = "0.4"
+camerak = "1.0"
 
 [libraries]
 camerak = { module = "io.github.kashif-mehmood-km:camerak", version.ref = "camerak" }
@@ -55,7 +55,7 @@ kotlin {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.4")
+    implementation("io.github.kashif-mehmood-km:camerak:1.0")
 }
 ```
 
@@ -105,7 +105,7 @@ Run Gradle sync:
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
 }
 ```
 
@@ -113,7 +113,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
 }
 ```
 
@@ -121,7 +121,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
 }
 ```
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -40,7 +40,7 @@ Plugins activate automatically when camera reaches `Ready` state.
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
 }
 ```
 
@@ -114,7 +114,7 @@ fun QRScannerScreen() {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
 }
 ```
 
@@ -188,7 +188,7 @@ fun OCRScannerScreen() {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
 }
 ```
 

--- a/docs/guides/video-recording.md
+++ b/docs/guides/video-recording.md
@@ -49,7 +49,7 @@ Add the plugin dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:0.4")
+    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:1.0")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:0.4")
+    implementation("io.github.kashif-mehmood-km:camerak:1.0")
 }
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -405,7 +405,7 @@ Include:
 
 **Good issue:**
 ```
-Kamera 0.4
+Kamera 1.0
 Android 13 (Pixel 6)
 
 Preview shows black screen when using:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/kashif-e/Kamera
       name: GitHub
-  version: 0.4
+  version: 1.0
 
 extra_css:
   - stylesheets/extra.css

--- a/ocrPlugin/build.gradle.kts
+++ b/ocrPlugin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.kashif.ocr_plugin"
-version = "0.4"
+version = "1.0"
 
 kotlin {
     jvmToolchain(17)
@@ -84,7 +84,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "ocr_plugin",
-        version = "0.4",
+        version = "1.0",
     )
 
     pom {

--- a/qrScannerPlugin/build.gradle.kts
+++ b/qrScannerPlugin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.kashif.qr_scanner_plugin"
-version = "0.4"
+version = "1.0"
 
 kotlin {
     jvmToolchain(17)
@@ -83,7 +83,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "qr_scanner_plugin",
-        version = "0.4",
+        version = "1.0",
     )
 
     pom {

--- a/videoRecorderPlugin/build.gradle.kts
+++ b/videoRecorderPlugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.kashif.video_recorder_plugin"
-version = "0.4"
+version = "1.0"
 
 kotlin {
     jvmToolchain(17)
@@ -68,7 +68,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "video_recorder_plugin",
-        version = "0.4",
+        version = "1.0",
     )
 
     pom {


### PR DESCRIPTION
Bumps all published modules and documentation from `0.4` to **1.0** for the release.

- **Modules**: `cameraK`, `image_saver_plugin`, `qr_scanner_plugin`, `ocr_plugin`, `video_recorder_plugin`, `analyzer_plugin` → `1.0` (build version + Maven coordinates).
- **Docs**: README + docs dependency snippets and version strings → `1.0`.
- **CHANGELOG**: `[Unreleased]` → `[1.0] - 2026-06-19` (covers the aspect-ratio #137, iOS exposure #138, and plugin-lifecycle #140 work already on main).

Verified: `:cameraK:properties` reports `version: 1.0`.

After merge, publish via the cross-repo workflow (KMPLiquidGlass) with `ref` set to the `1.0` tag.