### PR TITLE
Publish workflow: bump to JDK 17

### DIFF
--- a/.github/workflows/UploadLibToCentral.yml
+++ b/.github/workflows/UploadLibToCentral.yml
@@ -6,17 +6,16 @@ on:
 jobs:
   build:
     runs-on: macos-latest
-    size: large
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Decode GPG Key
         run: echo "${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}" | base64 --decode > $HOME/secring.gpg


### PR DESCRIPTION
The project moved to a JDK 17 toolchain (#117-era), but `UploadLibToCentral.yml` still set up JDK 11 — `./gradlew build` would fail there. Bumps to `temurin` 17 and removes the invalid `size: large` job key. Needed before the 1.0 Maven Central publish can run from this repo.