### PR TITLE
Fix Maven Central publish OOM (iOS native link)

### DIFF
--- a/.github/workflows/UploadLibToCentral.yml
+++ b/.github/workflows/UploadLibToCentral.yml
@@ -5,7 +5,8 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # 14 GB runner; macos-latest (Apple silicon) only has ~7 GB which OOMs the iOS native link.
+    runs-on: macos-13
 
     steps:
       - name: Checkout code
@@ -17,11 +18,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Raise Gradle heap for the Kotlin/Native link
+        run: |
+          mkdir -p ~/.gradle
+          echo "org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=1g" >> ~/.gradle/gradle.properties
+
       - name: Decode GPG Key
         run: echo "${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}" | base64 --decode > $HOME/secring.gpg
-
-      - name: Build with Gradle
-        run: ./gradlew build
 
       - name: Publish to Maven Central
         run: |

--- a/.github/workflows/UploadLibToCentral.yml
+++ b/.github/workflows/UploadLibToCentral.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Raise Gradle heap for the Kotlin/Native link
         run: |
           mkdir -p ~/.gradle
+          touch ~/.gradle/gradle.properties
+          # Set (not blindly append) so a re-run / pre-existing entry can't create duplicates.
+          sed -i.bak '/^org.gradle.jvmargs=/d' ~/.gradle/gradle.properties && rm -f ~/.gradle/gradle.properties.bak
           echo "org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=1g" >> ~/.gradle/gradle.properties
 
       - name: Decode GPG Key


### PR DESCRIPTION
The 1.0 publish failed with `java.lang.OutOfMemoryError` in `:cameraK:linkReleaseFrameworkIosArm64` (Kotlin/Native LTO DevirtualizationAnalysis).

Root cause: the workflow ran `./gradlew build` before publishing, which links the **release iOS framework** with LTO — extremely memory-hungry and **not needed** for a Maven Central *library* publish (klibs are published, not the linked framework). `macos-latest` is now the ~7 GB Apple-silicon runner, so it OOMs.

Fix:
- Drop the redundant `./gradlew build` step (the publish task builds the klibs it needs).
- Run on `macos-13` (14 GB, free).
- Raise the Gradle heap to 10g via `~/.gradle/gradle.properties` for the native compiles.