### PR TITLE
Fix white header flash on aspect-ratio change (Sample)

### DIFF
--- a/Sample/src/commonMain/kotlin/org/company/app/App.kt
+++ b/Sample/src/commonMain/kotlin/org/company/app/App.kt
@@ -132,6 +132,9 @@ fun App() = AppTheme {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
+        // Camera app: black background so the preview re-bind on aspect-ratio change (and any
+        // letterbox bars) never flashes the default white surface.
+        containerColor = Color.Black,
     ) {
         val cameraPermissionState = remember { mutableStateOf(permissions.hasCameraPermission()) }
         val storagePermissionState = remember { mutableStateOf(permissions.hasStoragePermission()) }


### PR DESCRIPTION
## Problem
Changing the aspect ratio in the Sample app flashed a **white header** during the camera re-init.

## Cause
The root \`Scaffold\` used its default \`containerColor\` (= \`MaterialTheme.colorScheme.background\`, white). Changing the aspect ratio rebuilds the \`CameraConfiguration\` and re-initializes the camera; the native preview surface is torn down and rebuilt, and for a frame the Compose tree showed the white Scaffold background behind it.

## Fix
Set the Scaffold \`containerColor = Color.Black\` — a camera app should never show a white surface behind/around the preview (also covers letterbox bars).

## Verified
On a Galaxy S23: rapid screencaps during repeated aspect-ratio changes — status-bar and header regions sample pure black (0,0,0) across all transition frames. Was white before.