### PR TITLE
Release 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1] - 2026-06-30
+
 ### Fixed
 - **Android photos cropped / reduced field-of-view** (#136): captured stills were zoomed-in vs the preview (e.g. a 4080×3060 sensor saved as a 3060×2295 centre crop). Cause: CameraK always bound a 16:9 `VideoCapture` use case in the photo `UseCaseGroup`, and the shared `ViewPort` had to fit every use case — so the 16:9 video shrank the common field of view for the 4:3 still (StreamSharing masked it only when 4+ use cases were bound). `VideoCapture` is now bound lazily — only while a recording is active — so photos use the full sensor field of view. A lens/device switch or a second `startRecording()` during recording is now rejected (they would tear down or orphan the live session), and a failed recording start rolls back so later photos stay full-FOV. Verified on a Galaxy S23 across photo/record/photo-after-record.
 - **Android captured photo aspect ratio & orientation** (#136, follow-up): the 1.0 fix letterboxed the preview but, on real hardware, the **saved photo** still came out wrong — e.g. a portrait `RATIO_4_3` capture saved as a cropped 4:3 *landscape*. Root cause (found via on-device testing): three orientation sources disagreed — the capture rotation/EXIF was driven by the accelerometer while the ViewPort crop and preview followed the **display** rotation. Fixes: (1) the ViewPort `Rational` is now orientation-aware (portrait `RATIO_4_3` → 3:4) and rebuilt on a portrait↔landscape rotation; (2) capture `targetRotation` now follows the display rotation — the same source as the ViewPort and preview — so all three agree (WYSIWYG). Verified on a Galaxy S23 across all four ratios × both orientations × with/without the analyzer plugin (StreamSharing).
+- **Android rotation during recording** (#147): a portrait↔landscape flip mid-recording no longer tears down the active recording. The ViewPort rebuild is deferred and applied when the recording finalizes; a recording that finalizes on error also clears its state so later rotations rebind correctly. `setTargetOrientation(null)` now reverts to the display rotation (consistent with auto mode) instead of a possibly-stale sensor orientation.
 
 ### Changed (behavior)
 - **`targetResolution` no longer overrides `aspectRatio`** (Android): when both are set, the aspect ratio is the primary constraint and the resolution is the preferred size within it. Previously a target like `1920×1080` forced 16:9 output even when `RATIO_4_3` was requested.

--- a/ImageSaverPlugin/build.gradle.kts
+++ b/ImageSaverPlugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.kashif.image_saver_plugin"
-version = "1.0"
+version = "1.1"
 
 kotlin {
     jvmToolchain(17)
@@ -75,7 +75,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "image_saver_plugin",
-        version = "1.0",
+        version = "1.1",
     )
 
     pom {

--- a/README.MD
+++ b/README.MD
@@ -34,14 +34,14 @@ Add dependencies to your `build.gradle.kts`:
 ```kotlin
 dependencies {
     // Core library
-    implementation("io.github.kashif-mehmood-km:camerak:1.0")
+    implementation("io.github.kashif-mehmood-km:camerak:1.1")
 
     // Optional plugins
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
-    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:1.0")
-    implementation("io.github.kashif-mehmood-km:analyzer_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.1")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.1")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.1")
+    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:1.1")
+    implementation("io.github.kashif-mehmood-km:analyzer_plugin:1.1")
 }
 ```
 
@@ -994,10 +994,10 @@ LaunchedEffect(ocrPlugin) {
 
 ```gradle
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:1.0")
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:camerak:1.1")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.1")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.1")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.1")
 }
 ```
 

--- a/analyzerPlugin/build.gradle.kts
+++ b/analyzerPlugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.kashif.analyzer_plugin"
-version = "1.0"
+version = "1.1"
 
 kotlin {
     jvmToolchain(17)
@@ -83,7 +83,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "analyzer_plugin",
-        version = "1.0",
+        version = "1.1",
     )
 
     pom {

--- a/cameraK/build.gradle.kts
+++ b/cameraK/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.kashif.camera_compose"
-version = "1.0"
+version = "1.1"
 
 kotlin {
     jvmToolchain(17)
@@ -106,7 +106,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "camerak",
-        version = "1.0",
+        version = "1.1",
     )
 
     pom {

--- a/docs/examples/android.md
+++ b/docs/examples/android.md
@@ -16,7 +16,7 @@ Setup Kamera for Android applications.
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:1.0")
+    implementation("io.github.kashif-mehmood-km:camerak:1.1")
 }
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ Add to your `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.kashif-mehmood-km:camerak:1.0")
+            implementation("io.github.kashif-mehmood-km:camerak:1.1")
         }
     }
 }
@@ -55,7 +55,7 @@ kotlin {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:1.0")
+    implementation("io.github.kashif-mehmood-km:camerak:1.1")
 }
 ```
 
@@ -105,7 +105,7 @@ Run Gradle sync:
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.1")
 }
 ```
 
@@ -113,7 +113,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.1")
 }
 ```
 
@@ -121,7 +121,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.1")
 }
 ```
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -40,7 +40,7 @@ Plugins activate automatically when camera reaches `Ready` state.
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:qr_scanner_plugin:1.1")
 }
 ```
 
@@ -114,7 +114,7 @@ fun QRScannerScreen() {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:ocr_plugin:1.1")
 }
 ```
 
@@ -188,7 +188,7 @@ fun OCRScannerScreen() {
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:image_saver_plugin:1.1")
 }
 ```
 

--- a/docs/guides/video-recording.md
+++ b/docs/guides/video-recording.md
@@ -49,7 +49,7 @@ Add the plugin dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:1.0")
+    implementation("io.github.kashif-mehmood-km:video_recorder_plugin:1.1")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 ```kotlin
 dependencies {
-    implementation("io.github.kashif-mehmood-km:camerak:1.0")
+    implementation("io.github.kashif-mehmood-km:camerak:1.1")
 }
 ```
 

--- a/ocrPlugin/build.gradle.kts
+++ b/ocrPlugin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.kashif.ocr_plugin"
-version = "1.0"
+version = "1.1"
 
 kotlin {
     jvmToolchain(17)
@@ -84,7 +84,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "ocr_plugin",
-        version = "1.0",
+        version = "1.1",
     )
 
     pom {

--- a/qrScannerPlugin/build.gradle.kts
+++ b/qrScannerPlugin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.kashif.qr_scanner_plugin"
-version = "1.0"
+version = "1.1"
 
 kotlin {
     jvmToolchain(17)
@@ -83,7 +83,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "qr_scanner_plugin",
-        version = "1.0",
+        version = "1.1",
     )
 
     pom {

--- a/videoRecorderPlugin/build.gradle.kts
+++ b/videoRecorderPlugin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.kashif.video_recorder_plugin"
-version = "1.0"
+version = "1.1"
 
 kotlin {
     jvmToolchain(17)
@@ -68,7 +68,7 @@ mavenPublishing {
     coordinates(
         groupId = "io.github.kashif-mehmood-km",
         artifactId = "video_recorder_plugin",
-        version = "1.0",
+        version = "1.1",
     )
 
     pom {


### PR DESCRIPTION
Bumps all published modules `1.0` → `1.1` and finalizes the changelog.

## Included since 1.0
- **#136** Android photos cropped / reduced field-of-view — lazy `VideoCapture` binding + recording-lifecycle guards
- **#136 follow-up** captured photo aspect ratio & orientation (display-driven ViewPort + capture rotation)
- **#147** rotation during recording — deferred ViewPort rebuild, `setTargetOrientation(null)` reverts to display rotation

## Changes
- `version = "1.1"` across all 6 modules (project + Maven coordinate)
- README + `docs/` install snippets → `1.1`
- CHANGELOG `[Unreleased]` → `[1.1] - 2026-06-30`

After merge: tag `1.1` and run the **Upload Library to Maven Central** workflow.