### PR TITLE
Fix Mac Catalyst crash in QR/barcode metadata setup (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Crash on Mac Catalyst during QR/barcode setup** (#70): the scanner assigned a fixed list of 13 metadata object types, but a Mac camera advertises far fewer (sometimes none). Assigning a type not in `availableMetadataObjectTypes` aborts the process (`NSInvalidArgumentException` in `_buildAndRunGraph`). CameraK now only ever assigns the intersection with the supported types, so QR scanning degrades gracefully on Mac/Catalyst instead of crashing. iPhone/iPad behavior is unchanged (all types remain supported). Note: this covers running an iOS app via Mac Catalyst; a native macOS (AppKit) target is not yet provided.
+
 ## [1.1] - 2026-06-30
 
 ### Fixed

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -255,18 +255,18 @@ actual class CameraController(
     }
 
     fun updateMetadataObjectTypes(newTypes: List<String>) {
-        // Note: This is called from queueConfigurationChange, so session may be in config mode
-        // Don't check isRunning() - just set the types
-        if (metadataOutput.availableMetadataObjectTypes.isNotEmpty()) {
-            // Filter to only supported types
-            val supportedTypes = newTypes.filter { type ->
-                metadataOutput.availableMetadataObjectTypes.contains(type)
-            }
-            metadataOutput.metadataObjectTypes = supportedTypes
-        } else {
-            // Metadata output not fully ready yet, try setting all requested types
-            metadataOutput.metadataObjectTypes = newTypes
-        }
+        // Only ever assign the intersection with availableMetadataObjectTypes. Assigning a type the
+        // hardware doesn't advertise throws NSInvalidArgumentException (SIGABRT) inside
+        // _buildAndRunGraph — most visible on Mac Catalyst, where the camera advertises far fewer
+        // barcode types than an iPhone (and sometimes none). Never force-set the full list. (#70)
+        val available = metadataOutput.availableMetadataObjectTypes
+        val supportedTypes = newTypes.filter { available.contains(it) }
+        // Nothing supported yet: the output isn't connected, or the platform (some Macs) advertises
+        // no barcode metadata types at all. Leave types unset — scanning is a no-op, not a crash.
+        // (A Kotlin try/catch can't rescue this: an NSException from the setter aborts the process,
+        // so the filter — never assigning an unavailable type — IS the guard.)
+        if (supportedTypes.isEmpty()) return
+        metadataOutput.metadataObjectTypes = supportedTypes
     }
 
     @OptIn(ExperimentalForeignApi::class)


### PR DESCRIPTION
Closes the crash reported in #70 (running a KMP iOS app on macOS via **Mac Catalyst**).

## Cause
`QRScannerPlugin` requests 13 barcode/QR metadata object types. `CameraController.updateMetadataObjectTypes` filtered them against `availableMetadataObjectTypes` **only when that list was non-empty**, and otherwise **force-set all 13**. A Mac camera advertises far fewer types (sometimes none), so assigning an unavailable type throws `NSInvalidArgumentException` → `SIGABRT` inside `-[AVCaptureSession _buildAndRunGraph:]`.

## Fix
Only ever assign the intersection with `availableMetadataObjectTypes`; if nothing is supported, leave types unset (scanning is a no-op, not a crash). A Kotlin `try/catch` can't rescue this — an `NSException` from the setter aborts the process — so the filter itself is the guard.

## No iOS regression
`metadataOutput` is added and the session started in `onSessionReady`, which completes before the controller reports Ready and before the QR plugin attaches and calls `updateMetadataObjectTypes`. So on iPhone/iPad `availableMetadataObjectTypes` is fully populated by then → all 13 types are set, exactly as before. The behavior only diverges on Mac/Catalyst.

## Scope
This makes CameraK usable under **Mac Catalyst** (which runs the existing `iosArm64`/`x64` slice — no new target needed). A **native macOS (AppKit) target** is a separate, larger effort (preview via `NSView`, no torch/orientation, different device discovery) and is *not* included here.

## Testing
Compiles on the iOS target; spotless clean. Live QR scanning can't be exercised in CI (simulators have no camera); logic verified against the setup ordering. Ideally confirmed by @zhimbura on Catalyst.