### PR TITLE
Publish on macos-15 with a 5g heap

### DIFF
--- a/.github/workflows/UploadLibToCentral.yml
+++ b/.github/workflows/UploadLibToCentral.yml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   build:
-    # 14 GB runner; macos-latest (Apple silicon) only has ~7 GB which OOMs the iOS native link.
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - name: Checkout code
@@ -18,13 +17,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Raise Gradle heap for the Kotlin/Native link
+      - name: Set Gradle heap for the Kotlin/Native link
         run: |
           mkdir -p ~/.gradle
           touch ~/.gradle/gradle.properties
           # Set (not blindly append) so a re-run / pre-existing entry can't create duplicates.
           sed -i.bak '/^org.gradle.jvmargs=/d' ~/.gradle/gradle.properties && rm -f ~/.gradle/gradle.properties.bak
-          echo "org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=1g" >> ~/.gradle/gradle.properties
+          # macos-15 is Apple silicon with ~7 GB; -Xmx5g leaves room for the Kotlin/Native linker itself.
+          echo "org.gradle.jvmargs=-Xmx5g -XX:MaxMetaspaceSize=1g" >> ~/.gradle/gradle.properties
 
       - name: Decode GPG Key
         run: echo "${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}" | base64 --decode > $HOME/secring.gpg


### PR DESCRIPTION
`macos-13` is Intel-only and being retired. Moves the release job to `macos-15` (Apple silicon, ~7 GB) and drops the Gradle heap from `-Xmx10g` to `-Xmx5g` so the Kotlin/Native linker has room alongside the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)